### PR TITLE
Add csharp_configure rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.swp
+*~
+/bazel-bin
+/bazel-genfiles
+/bazel-out
+/bazel-rules_dotnet
+/bazel-testlogs

--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_dotnet.git",
     tag = "0.0.1",
 )
-load("@io_bazel_rules_dotnet//dotnet:csharp.bzl", "csharp_repositories")
-
+load(
+    "@io_bazel_rules_dotnet//dotnet:csharp.bzl",
+    "csharp_repositories",
+    "csharp_configure",
+)
 csharp_repositories()
+csharp_configure()
 ```
+
+The `csharp_repositories` rule fetches external dependencies, namely the NUnit
+binaries, and the `csharp_configure` rule sets up the rules to use the local
+Mono C# toolchain installed on your system.
 
 ## Examples
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,6 @@
 workspace(name = "io_bazel_rules_dotnet")
 
-load("//dotnet:csharp.bzl", "csharp_repositories")
+load("//dotnet:csharp.bzl", "csharp_repositories", "csharp_configure")
 csharp_repositories()
+
+csharp_configure()

--- a/dotnet/nunit.BUILD
+++ b/dotnet/nunit.BUILD
@@ -1,0 +1,17 @@
+filegroup(
+    name = "nunit_exe",
+    srcs = ["NUnit-2.6.4/bin/nunit-console.exe"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "nunit_exe_libs",
+    srcs = glob(["NUnit-2.6.4/bin/lib/*.dll"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "nunit_framework",
+    srcs = glob(["NUnit-2.6.4/bin/framework/*.dll"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Add csharp_configure rule to find and use the Mono C# toolchain installed on the local system.

Also, add inline documentation for rules and macros.

Fixes #1