### PR TITLE
Bazel mirror Nunit

### DIFF
--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -517,7 +517,7 @@ def csharp_repositories(use_local_mono=False):
   """Adds the repository rules needed for using the C# rules."""
   native.new_http_archive(
       name = "nunit",
-      url = "https://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4.zip",
+      url = "http://bazel-mirror.storage.googleapis.com/github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4.zip",
       sha256 = "1bd925514f31e7729ccde40a38a512c2accd86895f93465f3dfe6d0b593d7170",
       type = "zip",
       # This is a little weird but is necessary for the build file reference to


### PR DESCRIPTION
I noticed you're already using bazel-mirror for one of your other downloads. So I figured, why not this one too?

You might also find this bash command helpful in the future for mirroring:

```bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```