### PR TITLE
Fix build on Linux

### DIFF
--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -240,7 +240,7 @@ def _cs_nunit_run_impl(ctx):
       depinfo)
 
   _csc_compile_action(ctx, output, outputs, collected_inputs,
-                      extra_refs=["Nunit.Framework"])
+                      extra_refs=["nunit.framework"])
 
   _make_nunit_launcher(ctx, depinfo, output)
 

--- a/dotnet/nunit.BUILD
+++ b/dotnet/nunit.BUILD
@@ -12,6 +12,6 @@ filegroup(
 
 filegroup(
     name = "nunit_framework",
-    srcs = glob(["NUnit-2.6.4/bin/framework/*.dll"]),
+    srcs = glob(["NUnit-2.6.4/bin/framework/*"]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This doesn't fix Jenkins, but it does let you do `bazel build //...` on Linux. I was initially getting the error:

```
error CS0006: Metadata file `Nunit.Framework' could not be found`
```

The file's name is nunit.framework.xml, so AFAICT on a case-sensitive filesystems, it was looking for Nunit.Framework.xml.  Then it couldn't find nunit.framework.xml anyway, since the nunit_framework target only included the .dlls (not the .xml file).
