### PR TITLE
Deactivate sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
   </ul>
 </div>
 
+__WARNING:__ Theses rules are not compatible with
+[sandboxing](https://bazel.io/blog/2015/09/11/sandboxing.html).
+
+
 ## Overview
 
 This is a minimal viable set of C# bindings for building csharp code with

--- a/README.md
+++ b/README.md
@@ -2,15 +2,12 @@
 
 ## Rules
 
-<div class="toc">
-  <ul>
-    <li><a href="#csharp_library">csharp_library</a></li>
-    <li><a href="#csharp_binary">csharp_binary</a></li>
-    <li><a href="#csharp_nunit_test">csharp_nunit_test</a></li>
-    <li><a href="#nuget_package">nuget_package</a></li>
-    <li><a href="#dll_import">dll_import</a></li>
-  </ul>
-</div>
+
+* [csharp_library](#csharp_library)
+* [csharp_binary](#csharp_library)
+* [csharp_nunit_test](#csharp_nunit_test)
+* [nuget_package](#nuget_package)
+* [dll_import](#dll_import)
 
 __WARNING:__ Theses rules are not compatible with
 [sandboxing](https://bazel.io/blog/2015/09/11/sandboxing.html).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ## Rules
 
 <div class="toc">
-  <h2>Rules</h2>
   <ul>
     <li><a href="#csharp_library">csharp_library</a></li>
     <li><a href="#csharp_binary">csharp_binary</a></li>

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,1 @@
+build --genrule_strategy=standalone --spawn_strategy=standalone


### PR DESCRIPTION
Because of spaces in file names of the mono framework, it cannot be
shipped into the sandbox, so deactivate sandboxing for now for this project.

This should make ci.bazel.io green again.

Also remove the extraneous 'Rules' in the README.md
