### PR TITLE
Adds RULES_DOTNET_USE_LOCAL_MONO environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,13 @@ nuget_package(
 
 The `csharp_repositories` rule fetches external dependencies, namely
 the mono repository, the nuget binary, and the nunit binary. Setting
-`use_local_mono` to `True` will use your installed mono framework
-instead of downloading one. If you are on OS X you can set
+the environment variable `RULES_DOTNET_USE_LOCAL_MONO=1` or the rule
+argument `use_local_mono` to `True` will use your installed mono
+framework instead of downloading one. If you are on OS X you can set
 `use_local_mono` to `False` and mono will be downloaded for you by
-bazel. Support for downloading mono on Linux is coming soon.
+bazel.
+
+Support for downloading mono on Linux is coming soon.
 
 ## Examples
 

--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -543,7 +543,9 @@ exports_files(["mono", "mcs"])
   repository_ctx.file("bin/BUILD", toolchain_build)
 
 def _mono_repository_impl(repository_ctx):
-  if repository_ctx.attr.use_local:
+  use_local = repository_ctx.os.environ.get(
+    "RULES_DOTNET_USE_LOCAL_MONO", repository_ctx.attr.use_local)
+  if use_local:
     _csharp_autoconf(repository_ctx)
   elif repository_ctx.os.name.find("mac") != -1:
     _mono_osx_repository_impl(repository_ctx)


### PR DESCRIPTION
- Setting this variable to a truthy value is equivalent to setting
  the use_local_mono=True.

This is useful for CI when you don't want to have to check in the
value of the flag to version control.