### PR TITLE
Adds cfg parameter to executable labels, now required by bazel.

### DIFF
--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -302,12 +302,14 @@ _COMMON_ATTRS = {
         allow_files = True,
         single_file = True,
         executable = True,
+        cfg = "host",
     ),
     "csc": attr.label(
         default = Label("@mono//bin:mcs"),
         allow_files = True,
         single_file = True,
         executable = True,
+        cfg = "host",
     ),
 }
 
@@ -468,6 +470,7 @@ _nuget_package_attrs = {
   "mono_exe":attr.label(
     executable=True,
     default=Label("@mono//bin:mono"),
+    cfg="host",
   ),
   # Reference to the nuget.exe file
   "nuget_exe":attr.label(


### PR DESCRIPTION
Avoids warnings such as:

```sh
WARNING: /home/deploy/.cache/bazel/_bazel_deploy/880282d5808fe6b81087b70dba214cb0/external/io_bazel_rules_dotnet/dotnet/csharp.bzl:300:13: Argument `cfg = "host"` or `cfg = "data"` is required if `executable = True` is provided for a label.
WARNING: /home/deploy/.cache/bazel/_bazel_deploy/880282d5808fe6b81087b70dba214cb0/external/io_bazel_rules_dotnet/dotnet/csharp.bzl:306:12: Argument `cfg = "host"` or `cfg = "data"` is required if `executable = True` is provided for a label.
WARNING: /home/deploy/.cache/bazel/_bazel_deploy/880282d5808fe6b81087b70dba214cb0/external/io_bazel_rules_dotnet/dotnet/csharp.bzl:468:14: Argument `cfg = "host"` or `cfg = "data"` is required if `executable = True` is provided for a label.
```