### PR TITLE
Make csharp_binary work correctly in genrule (#36)

### DIFF
--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -130,9 +130,9 @@ _LAUNCHER_SCRIPT = """\
 
 set -e
 
-if [[ -e "$0.runfiles" ]]; then
-  cd $0.runfiles/{workspace}
-fi
+RUNFILES=$0.runfiles/{workspace}
+
+pushd $RUNFILES
 
 # TODO(jeremy): This is a gross and fragile hack.
 # We should be able to do better than this.
@@ -141,7 +141,9 @@ for l in {libs}; do
     ln -s -f $l $(basename {workspace}/$l)
 done
 
-{mono_exe} $(basename {exe}) "$@"
+popd
+
+$RUNFILES/{mono_exe} $RUNFILES/$(basename {exe}) "$@"
 """
 
 def _make_launcher(ctx, depinfo, output):

--- a/examples/example_tool/BUILD
+++ b/examples/example_tool/BUILD
@@ -1,0 +1,34 @@
+load("//dotnet:csharp.bzl", "csharp_binary")
+
+csharp_binary(
+    name = "hello_tool",
+    srcs = [
+        "MyTool.cs",
+    ],
+    deps = [
+        "//examples/example_lib:MyClass",
+    ],
+)
+
+genrule(
+    name = "hello_single_output",
+    outs = [
+        "hello_world.txt",
+    ],
+    tools = [
+        ":hello_tool",
+    ],
+    cmd = "$(location :hello_tool) $@",
+)
+
+genrule(
+    name = "hello_multiple_outputs",
+    outs = [
+        "hello_world_1.txt",
+        "hello_world_2.txt",
+    ],
+    tools = [
+        ":hello_tool",
+    ],
+    cmd = "$(location :hello_tool) $(OUTS)",
+)

--- a/examples/example_tool/MyTool.cs
+++ b/examples/example_tool/MyTool.cs
@@ -1,0 +1,21 @@
+using System;
+using example_lib;
+
+namespace example_tool
+{
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            if (args.Length == 0) {
+                Console.Error.WriteLine("No output files specified!");
+                Environment.Exit(1);
+            }
+
+            var mc = new MyClass();
+            foreach (string output_file in args) {
+                System.IO.File.WriteAllText(output_file, mc.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The working directory needs to be preserved so that relative paths
work correctly. To fix this, we pushd/popd to set up runfiles
rather than just cd'ing into it.

example_tool tests this with both single-output and multi-output
genrules.