### PR TITLE
Use ctx.actions.run rather than ctx.action

### DIFF
--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -191,14 +191,12 @@ def _csc_compile_action(ctx, assembly, all_outputs, collected_inputs,
                       extra_refs=[]):
   csc_args = _make_csc_arglist(ctx, assembly, collected_inputs.depinfo,
                                extra_refs=extra_refs)
-  command_script = " ".join([ctx.file.csc.path] + csc_args +
-                            collected_inputs.srcs)
 
-  ctx.action(
+  ctx.actions.run(
       inputs = list(collected_inputs.inputs),
       outputs = all_outputs,
-      command = command_script,
-      arguments = csc_args,
+      executable = ctx.file.csc.path,
+      arguments = csc_args + collected_inputs.srcs,
       progress_message = (
           "Compiling " + ctx.label.package + ":" + ctx.label.name))
 


### PR DESCRIPTION
This is important/useful for Windows where we are more inclined to avoid bash.

This is particularly important in light of https://github.com/bazelbuild/bazel/issues/4013 which for me results in extremely slow builds on Windows (I'm running a fork of this repo with .NET framework support; I'll be upstreaming the simple platform-agnostic changes to start.)

`ctx.action` was recently deprecated; the details are [in the docs](https://docs.bazel.build/versions/master/skylark/lib/ctx.html#action).