### PR TITLE
Support embedded resources in csharp_* rules

### DIFF
--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -98,6 +98,8 @@ def _make_csc_arglist(ctx, output, depinfo, extra_refs=[]):
   if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
     args.add(_make_csc_flag(flag_start, "main", ctx.attr.main_class))
 
+  args.add(format="/resource:%s", value=ctx.files.resources)
+
   # TODO(jwall): /parallel
 
   return args
@@ -185,8 +187,8 @@ def _csc_get_output(ctx):
 
 def _csc_collect_inputs(ctx, extra_files=[]):
   depinfo = _make_csc_deps(ctx.attr.deps, extra_files=extra_files)
-  inputs = (depset(ctx.files.srcs) + depinfo.dlls + depinfo.transitive_dlls
-      + [ctx.file.csc])
+  inputs = (depset(ctx.files.srcs) + depset(ctx.files.resources) + depinfo.dlls
+      + depinfo.transitive_dlls + [ctx.file.csc])
   srcs = [src.path for src in ctx.files.srcs]
   return struct(depinfo=depinfo,
                 inputs=inputs,
@@ -321,7 +323,7 @@ _COMMON_ATTRS = {
     # source files for this target.
     "srcs": attr.label_list(allow_files = FileType([".cs", ".resx"])),
     # resources to use as dependencies.
-    # TODO(jeremy): "resources_deps": attr.label_list(allow_files=True),
+    "resources": attr.label_list(allow_files = True),
     # TODO(jeremy): # name of the module if you are creating a module.
     # TODO(jeremy): "modulename": attri.string(),
     # warn level to use

--- a/examples/example_lib/BUILD
+++ b/examples/example_lib/BUILD
@@ -6,6 +6,7 @@ csharp_library(
         "MyClass.cs",
         "Properties/AssemblyInfo.cs",
     ],
+    resources = [ "hello.txt" ],
     visibility = ["//visibility:public"],
     deps = [
         "//examples/example_transitive_lib:TransitiveClass",

--- a/examples/example_lib/hello.txt
+++ b/examples/example_lib/hello.txt
@@ -1,0 +1,2 @@
+Hello, World!
+This text file was included as an embedded resource


### PR DESCRIPTION
Notes

* I'm assuming #49 will get merged and not using `_make_csc_flag` when I `args.add` here. This PR **doesnt** depend on that one, however.
* It would probably be a good idea to ban `.resx` from the `resources` attribute (I think I'd have to throw an error in the impl?) but I'll explain this a bit more in an larger issue I'm going to open about resx files shortly (EDIT: #51).
* I tested this on Linux+Mono (I'm porting these changes from a Windows+.NET framework fork) and the output of `strings` on the `MyClass` DLL contains the text file (and the param file that is generated looks correct.)