### PR TITLE
(Skylint) Use dicts.add rather than deprecated +

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ might become especially valuable.
 Add the following to your `WORKSPACE` file to add the external repositories:
 
 ```python
+# A newer version should be fine
+http_archive(
+  name = "bazel_skylib",
+  url = "https://github.com/bazelbuild/bazel-skylib/archive/ff23a62c57d2912c3073a69c12f42c3d6e58a957.zip",
+  strip_prefix = "bazel-skylib-ff23a62c57d2912c3073a69c12f42c3d6e58a957",
+  sha256 = "ccf83f162e4a265b3aa09445c84fbc470215e392b250c86f0ce00536c99d5c17",
+)
+
 git_repository(
     name = "io_bazel_rules_dotnet",
     remote = "https://github.com/bazelbuild/rules_dotnet.git",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,11 @@
 workspace(name = "io_bazel_rules_dotnet")
 
+http_archive(
+  name = "bazel_skylib",
+  url = "https://github.com/bazelbuild/bazel-skylib/archive/ff23a62c57d2912c3073a69c12f42c3d6e58a957.zip",
+  strip_prefix = "bazel-skylib-ff23a62c57d2912c3073a69c12f42c3d6e58a957",
+  sha256 = "ccf83f162e4a265b3aa09445c84fbc470215e392b250c86f0ce00536c99d5c17",
+)
+
 load("//dotnet:csharp.bzl", "csharp_repositories")
 csharp_repositories()

--- a/dotnet/csharp.bzl
+++ b/dotnet/csharp.bzl
@@ -14,6 +14,8 @@
 
 """CSharp bazel rules"""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+
 _MONO_UNIX_BIN = "/usr/local/bin/mono"
 
 # TODO(jeremy): Windows when it's available.
@@ -533,12 +535,12 @@ def _new_nuget_package_impl(repository_ctx):
 
 new_nuget_package = repository_rule(
   implementation=_new_nuget_package_impl,
-  attrs=_nuget_package_attrs + {
+  attrs=dicts.add(_nuget_package_attrs, {
     "build_file": attr.label(
       allow_files = True,
     ),
     "build_file_content": attr.string(),
-  })
+  }))
 """Fetches a nuget package as an external dependency with custom BUILD content.
 
 Args:


### PR DESCRIPTION
Not urgent, but following the directions from the Skylint docs: https://github.com/bazelbuild/bazel/blob/7f86d4a34bbd76295b8753ffc2740e43aa228fc2/site/docs/skylark/skylint.md#using-the-operator--on-dictionaries-deprecated-plus-dict

A few questions:

0. Is this worth the dependency on skylib at all?
1. I assume it's desirable to have a standard name for importing something like skylib. "bazel_skylib" is mentioned by skylint docs (linked above) and is the name used in skylib's `WORKSPACE` file so I chose it here. This library uses "io_bazel_rules_dotnet" to refer to itself which looks like an attempt at a URI-based namespacing convention. Are there plans for conventions around naming external workspaces?
2. Is using a specific commit in the `http_archive` for skylint acceptable for now? (both our `WORKSPACE` and the `README`.)
3. This change isn't backwards compatible. The instructions in the `README` don't line up because it is pulling v0.3 of rules_dotnet which doesn't have these changes. Should we release a new version? Related: #33