### PR TITLE
Format all bzl files with Buildifier

### DIFF
--- a/dotnet/defs.bzl
+++ b/dotnet/defs.bzl
@@ -1,6 +1,6 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
-    dotnet_context = "dotnet_context",
+    "dotnet_context",
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/toolchain:toolchains.bzl",
@@ -8,85 +8,74 @@ load(
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/private:sdk.bzl",
-    dotnet_download_sdk = "dotnet_download_sdk",
-    dotnet_host_sdk = "dotnet_host_sdk",
-    dotnet_local_sdk = "dotnet_local_sdk",
+    "dotnet_download_sdk",
+    "dotnet_host_sdk",
+    "dotnet_local_sdk",
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/private:dotnet_toolchain.bzl",
-    dotnet_toolchain = "dotnet_toolchain",
+    "dotnet_toolchain",
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/private:repositories.bzl",
-    dotnet_repositories = "dotnet_repositories",
+    "dotnet_repositories",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/binary.bzl", 
-    dotnet_binary = "dotnet_binary",
-    core_binary = "core_binary",
-    net_binary = "net_binary"
+    "@io_bazel_rules_dotnet//dotnet/private:rules/binary.bzl",
+    "core_binary",
+    "dotnet_binary",
+    "net_binary",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/library.bzl", 
-    dotnet_library = "dotnet_library",
-    core_library = "core_library",
-    net_library = "net_library"
+    "@io_bazel_rules_dotnet//dotnet/private:rules/library.bzl",
+    "core_library",
+    "dotnet_library",
+    "net_library",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/resx.bzl", 
-    dotnet_resx = "dotnet_resx",
-    net_resx = "net_resx",
-    core_resx = "core_resx",
+    "@io_bazel_rules_dotnet//dotnet/private:rules/resx.bzl",
+    "core_resx",
+    "dotnet_resx",
+    "net_resx",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/resource_core.bzl", 
-    core_resource = "core_resource"
+    "@io_bazel_rules_dotnet//dotnet/private:rules/resource_core.bzl",
+    "core_resource",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/test.bzl", 
-    dotnet_nunit_test = "dotnet_nunit_test",
-    net_nunit_test = "net_nunit_test",
-    net_nunit3_test = "net_nunit3_test",
-    core_xunit_test = "core_xunit_test",
-    net_xunit_test = "net_xunit_test",
-    dotnet_xunit_test = "dotnet_xunit_test",
+    "@io_bazel_rules_dotnet//dotnet/private:rules/test.bzl",
+    "core_xunit_test",
+    "dotnet_nunit_test",
+    "dotnet_xunit_test",
+    "net_nunit3_test",
+    "net_nunit_test",
+    "net_xunit_test",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/nuget.bzl", 
-    dotnet_nuget = "dotnet_nuget",
-    dotnet_nuget_new = "dotnet_nuget_new",
-    nuget_package = "nuget_package"
+    "@io_bazel_rules_dotnet//dotnet/private:rules/nuget.bzl",
+    "dotnet_nuget",
+    "dotnet_nuget_new",
+    "nuget_package",
 )
-
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/import.bzl", 
-    dotnet_import_library = "dotnet_import_library",
-    core_import_library = "core_import_library",
-    net_import_library = "net_import_library",
-    dotnet_import_binary = "dotnet_import_binary",
-    core_import_binary = "core_import_binary",
-    net_import_binary = "net_import_binary",
+    "@io_bazel_rules_dotnet//dotnet/private:rules/import.bzl",
+    "core_import_binary",
+    "core_import_library",
+    "dotnet_import_binary",
+    "dotnet_import_library",
+    "net_import_binary",
+    "net_import_library",
 )
-
 load(
-    "@io_bazel_rules_dotnet//dotnet/private:rules/com_ref.bzl", 
-    net_com_library = "net_com_library"
+    "@io_bazel_rules_dotnet//dotnet/private:rules/com_ref.bzl",
+    "net_com_library",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:rules/gac_net.bzl",
-    net_gac4 = "net_gac4",
-    net_gac2 = "net_gac2"
+    "net_gac2",
+    "net_gac4",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:rules/vs_ref_net.bzl",
-    vs2017_ref_net = "vs2017_ref_net"
+    "vs2017_ref_net",
 )

--- a/dotnet/platform/list.bzl
+++ b/dotnet/platform/list.bzl
@@ -27,30 +27,30 @@ DOTNETIMPL_OS_ARCH = (
 )
 
 def declare_config_settings():
-  for impl in DOTNETIMPL:
-    native.config_setting(
-        name = impl,
-        #constraint_values = ["//dotnet/toolchain:" + impl],
-        values = {
-            "compilation_mode": impl
-        }
-    )
-  for os in DOTNETOS:
-    native.config_setting(
-        name = os,
-        constraint_values = ["//dotnet/toolchain:" + os],
-    )
-  for arch in DOTNETARCH:
-    native.config_setting(
-        name = arch,
-        constraint_values = ["//dotnet/toolchain:" + arch],
-    )
-  for impl, os, arch in DOTNETIMPL_OS_ARCH:
-    native.config_setting(
-        name = impl + "_" + os + "_" + arch,
-        constraint_values = [
-            "//dotnet/toolchain:" + os,
-            "//dotnet/toolchain:" + arch,
-            "//dotnet/toolchain:" + impl,
-        ],
-    )
+    for impl in DOTNETIMPL:
+        native.config_setting(
+            name = impl,
+            #constraint_values = ["//dotnet/toolchain:" + impl],
+            values = {
+                "compilation_mode": impl,
+            },
+        )
+    for os in DOTNETOS:
+        native.config_setting(
+            name = os,
+            constraint_values = ["//dotnet/toolchain:" + os],
+        )
+    for arch in DOTNETARCH:
+        native.config_setting(
+            name = arch,
+            constraint_values = ["//dotnet/toolchain:" + arch],
+        )
+    for impl, os, arch in DOTNETIMPL_OS_ARCH:
+        native.config_setting(
+            name = impl + "_" + os + "_" + arch,
+            constraint_values = [
+                "//dotnet/toolchain:" + os,
+                "//dotnet/toolchain:" + arch,
+                "//dotnet/toolchain:" + impl,
+            ],
+        )

--- a/dotnet/private/actions/assembly.bzl
+++ b/dotnet/private/actions/assembly.bzl
@@ -1,158 +1,158 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
     "DotnetResource",
 )
 
-
 def _map_dep(deps):
-  return [d[DotnetLibrary].result for d in deps]
+    return [d[DotnetLibrary].result for d in deps]
 
 def _map_resource(resources):
-  return [d[DotnetResource].result.path + "," + d[DotnetResource].identifier for d in resources]
+    return [d[DotnetResource].result.path + "," + d[DotnetResource].identifier for d in resources]
 
 def _make_runner_arglist(dotnet, deps, resources, output, executable, defines, unsafe, keyfile):
-  args = dotnet.actions.args()
+    args = dotnet.actions.args()
 
-  # /out:<file>
-  args.add(output.path, format="/out:%s",)
+    # /out:<file>
+    args.add(output.path, format = "/out:%s")
 
-  if executable:
-    target = "exe"
-  else:
-    target = "library"
-
-  # /target (exe for binary, library for lib, module for module)
-  args.add(target, format="/target:%s")
-
-  args.add("/fullpaths")
-  args.add("/noconfig")
-  args.add("/nostdlib")
-
-  # /warn
-  #args.add(format="/warn:%s", value=str(ctx.attr.warn))
-
-  # /nologo
-  args.add("/nologo")
-
-  # /modulename:<string> only used for modules
-  #libdirs = _get_libdirs(depinfo.dlls)
-  #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
-
-  # /lib:dir1,[dir1]
-  #if libdirs:
-  #  args.add(format="/lib:%s", value=libdirs)
-
-  if deps and len(deps)>0:
-    args.add(deps, format="/reference:%s", map_fn=_map_dep)
-
-  args.add(dotnet.stdlib, format="/reference:%s")
-
-  if defines and len(defines)>0:
-    args.add(defines, format="/define:%s")
-
-  if unsafe:
-    args.add("/unsafe")
-
-  if keyfile:
-    args.add("-keyfile:" + keyfile.files.to_list()[0].path)
-
-  # /debug
-  #debug = ctx.var.get("BINMODE", "") == "-dbg"
-  #if debug:
-  #  args.add("/debug")
-
-  # /warnaserror
-  # TODO(jeremy): /define:name[;name2]
-
-  if resources and len(resources)>0:
-    args.add(resources, format="/resource:%s", map_fn=_map_resource)
-
-  # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
-
-  # /main:class
-  #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
-  #  args.add(format="/main:%s", value=ctx.attr.main_class)
-
-  #args.add(format="/resource:%s", value=ctx.files.resources)
-
-  # TODO(jwall): /parallel
-
-  return args
-
-def emit_assembly(dotnet,
-    name = "",
-    srcs = None,
-    deps = None,
-    out = None,
-    resources = None,
-    executable = True,
-    defines = None,
-    unsafe = False,
-    data = None,
-    keyfile = None):
-  """See dotnet/toolchains.rst#binary for full documentation."""
-
-  if name == "" and out == None:
-    fail("either name or out must be set")
-
-  if not out:
     if executable:
-      extension = ".exe"
+        target = "exe"
     else:
-      extension = ".dll"
-    result = dotnet.declare_file(dotnet, path=name+extension)
-  else:
-    result = dotnet.declare_file(dotnet, path=out)  
-    extension = ""
-    
-  runner_args = _make_runner_arglist(dotnet, deps, resources, result, executable, defines, unsafe, keyfile)
+        target = "library"
 
-  attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
-  runner_args.add(attr_srcs)
+    # /target (exe for binary, library for lib, module for module)
+    args.add(target, format = "/target:%s")
 
-  runner_args.set_param_file_format("multiline")
+    args.add("/fullpaths")
+    args.add("/noconfig")
+    args.add("/nostdlib")
 
-  # Use a "response file" to pass arguments to csc.
-  # Windows has a max command-line length of around 32k bytes. The default for
-  # Args is to spill to param files if the length of the executable, params
-  # and spaces between them sum to that number. Unfortunately the math doesn't
-  # work out exactly like that on Windows (e.g. there is also a null
-  # terminator, escaping.) For now, setting use_always to True is the
-  # conservative option. Long command lines are probable with C# due to
-  # organizing files by namespace.
-  paramfilepath = name+extension+".param"
-  paramfile = dotnet.declare_file(dotnet, path=paramfilepath)
+    # /warn
+    #args.add(format="/warn:%s", value=str(ctx.attr.warn))
 
-  dotnet.actions.write(output = paramfile, content = runner_args)
+    # /nologo
+    args.add("/nologo")
 
-  deps_files = _map_dep(deps)
-  dotnet.actions.run(
-      inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
-      outputs = [result],
-      executable = dotnet.runner,
-      arguments = [dotnet.mcs.path, "@"+paramfile.path],
-      mnemonic = "MonoCompile",
-      progress_message = (
-          "Compiling " + dotnet.label.package + ":" + dotnet.label.name))
+    # /modulename:<string> only used for modules
+    #libdirs = _get_libdirs(depinfo.dlls)
+    #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
 
+    # /lib:dir1,[dir1]
+    #if libdirs:
+    #  args.add(format="/lib:%s", value=libdirs)
 
-  extra = [] if data == None else [d.files for d in data]
-  runfiles = depset(direct=[result] + [dotnet.stdlib], transitive=[d[DotnetLibrary].runfiles for d in deps] + extra)
-  transitive = depset(direct=deps, transitive=[a[DotnetLibrary].transitive for a in deps])
+    if deps and len(deps) > 0:
+        args.add(deps, format = "/reference:%s", map_fn = _map_dep)
 
-  return dotnet.new_library(
-    dotnet = dotnet, 
-    name = name, 
-    deps = deps, 
-    transitive = transitive,
-    result = result,
-    pdb = None,
-    runfiles=runfiles)
+    args.add(dotnet.stdlib, format = "/reference:%s")
 
+    if defines and len(defines) > 0:
+        args.add(defines, format = "/define:%s")
+
+    if unsafe:
+        args.add("/unsafe")
+
+    if keyfile:
+        args.add("-keyfile:" + keyfile.files.to_list()[0].path)
+
+    # /debug
+    #debug = ctx.var.get("BINMODE", "") == "-dbg"
+    #if debug:
+    #  args.add("/debug")
+
+    # /warnaserror
+    # TODO(jeremy): /define:name[;name2]
+
+    if resources and len(resources) > 0:
+        args.add(resources, format = "/resource:%s", map_fn = _map_resource)
+
+    # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
+
+    # /main:class
+    #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
+    #  args.add(format="/main:%s", value=ctx.attr.main_class)
+
+    #args.add(format="/resource:%s", value=ctx.files.resources)
+
+    # TODO(jwall): /parallel
+
+    return args
+
+def emit_assembly(
+        dotnet,
+        name = "",
+        srcs = None,
+        deps = None,
+        out = None,
+        resources = None,
+        executable = True,
+        defines = None,
+        unsafe = False,
+        data = None,
+        keyfile = None):
+    """See dotnet/toolchains.rst#binary for full documentation."""
+
+    if name == "" and out == None:
+        fail("either name or out must be set")
+
+    if not out:
+        if executable:
+            extension = ".exe"
+        else:
+            extension = ".dll"
+        result = dotnet.declare_file(dotnet, path = name + extension)
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
+        extension = ""
+
+    runner_args = _make_runner_arglist(dotnet, deps, resources, result, executable, defines, unsafe, keyfile)
+
+    attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
+    runner_args.add(attr_srcs)
+
+    runner_args.set_param_file_format("multiline")
+
+    # Use a "response file" to pass arguments to csc.
+    # Windows has a max command-line length of around 32k bytes. The default for
+    # Args is to spill to param files if the length of the executable, params
+    # and spaces between them sum to that number. Unfortunately the math doesn't
+    # work out exactly like that on Windows (e.g. there is also a null
+    # terminator, escaping.) For now, setting use_always to True is the
+    # conservative option. Long command lines are probable with C# due to
+    # organizing files by namespace.
+    paramfilepath = name + extension + ".param"
+    paramfile = dotnet.declare_file(dotnet, path = paramfilepath)
+
+    dotnet.actions.write(output = paramfile, content = runner_args)
+
+    deps_files = _map_dep(deps)
+    dotnet.actions.run(
+        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
+        outputs = [result],
+        executable = dotnet.runner,
+        arguments = [dotnet.mcs.path, "@" + paramfile.path],
+        mnemonic = "MonoCompile",
+        progress_message = (
+            "Compiling " + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
+
+    extra = [] if data == None else [d.files for d in data]
+    runfiles = depset(direct = [result] + [dotnet.stdlib], transitive = [d[DotnetLibrary].runfiles for d in deps] + extra)
+    transitive = depset(direct = deps, transitive = [a[DotnetLibrary].transitive for a in deps])
+
+    return dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        result = result,
+        pdb = None,
+        runfiles = runfiles,
+    )

--- a/dotnet/private/actions/assembly_core.bzl
+++ b/dotnet/private/actions/assembly_core.bzl
@@ -1,160 +1,160 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
     "DotnetResource",
 )
 
-
 def _map_dep(deps):
-  return [d[DotnetLibrary].result for d in deps]
+    return [d[DotnetLibrary].result for d in deps]
 
 def _map_resource(resources):
-  return [d[DotnetResource].result.path + "," + d[DotnetResource].identifier for d in resources]
+    return [d[DotnetResource].result.path + "," + d[DotnetResource].identifier for d in resources]
 
 def _make_runner_arglist(dotnet, deps, resources, output, pdb, executable, defines, unsafe, keyfile):
-  args = dotnet.actions.args()
+    args = dotnet.actions.args()
 
-  # /out:<file>
-  args.add(output.path, format="/out:%s")
+    # /out:<file>
+    args.add(output.path, format = "/out:%s")
 
-  if executable:
-    target = "exe"
-  else:
-    target = "library"
-
-  # /target (exe for binary, library for lib, module for module)
-  args.add(target, format="/target:%s")
-
-  args.add("/fullpaths")
-  args.add("/nostdlib")
-  args.add("/langversion:latest")
-  args.add("/nologo")
-
-  if pdb:
-    args.add("-debug:full")
-    args.add("-pdb:" + pdb.path)
-
-  # /warn
-  #args.add(format="/warn:%s", value=str(ctx.attr.warn))
-
-  # /modulename:<string> only used for modules
-  #libdirs = _get_libdirs(depinfo.dlls)
-  #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
-
-  # /lib:dir1,[dir1]
-  #if libdirs:
-  #  args.add(format="/lib:%s", value=libdirs)
-
-  if deps and len(deps)>0:
-    args.add(deps, format="/reference:%s", map_fn=_map_dep)
-
-  args.add(dotnet.stdlib, format="/reference:%s")
-
-  if defines and len(defines)>0:
-    args.add(defines, format="/define:%s")
-
-  if unsafe:
-    args.add("/unsafe")
-
-  if keyfile:
-    args.add("-keyfile:" + keyfile.files.to_list()[0].path)
-
-
-  # /debug
-  #debug = ctx.var.get("BINMODE", "") == "-dbg"
-  #if debug:
-  #  args.add("/debug")
-
-  # /warnaserror
-  # TODO(jeremy): /define:name[;name2]
-
-  if resources and len(resources)>0:
-    args.add(resources, format="/resource:%s", map_fn=_map_resource)
-
-  # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
-
-  # /main:class
-  #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
-  #  args.add(format="/main:%s", value=ctx.attr.main_class)
-
-  #args.add(format="/resource:%s", value=ctx.files.resources)
-
-  # TODO(jwall): /parallel
-
-  return args
-
-def emit_assembly_core(dotnet,
-    name,
-    srcs,
-    deps = None,
-    out = None,
-    resources = None,
-    executable = True,
-    defines = None,
-    unsafe = False,
-    data = None,
-    keyfile = None):
-  """See dotnet/toolchains.rst#binary for full documentation."""
-
-  if name == "" and out == None:
-    fail("either name or out must be set")
-
-  if not out:
     if executable:
-      extension = ".exe"
+        target = "exe"
     else:
-      extension = ".dll"
-    result = dotnet.declare_file(dotnet, path=name+extension)
-  else:
-    result = dotnet.declare_file(dotnet, path=out)  
-    extension = ""
-    
-  if dotnet.debug:
-    pdb = dotnet.declare_file(dotnet, path=name+".pdb")
-  else:
-    pdb = None
+        target = "library"
 
-  deps_libraries = [d[DotnetLibrary] for d in deps]  
-  transitive = depset(direct = deps, transitive = [d[DotnetLibrary].transitive for d in deps])
+    # /target (exe for binary, library for lib, module for module)
+    args.add(target, format = "/target:%s")
 
-  runner_args = _make_runner_arglist(dotnet, transitive.to_list(), resources, result, pdb, executable, defines, unsafe, keyfile)
+    args.add("/fullpaths")
+    args.add("/nostdlib")
+    args.add("/langversion:latest")
+    args.add("/nologo")
 
-  attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
-  runner_args.add(attr_srcs)
+    if pdb:
+        args.add("-debug:full")
+        args.add("-pdb:" + pdb.path)
 
-  runner_args.set_param_file_format("multiline")
+    # /warn
+    #args.add(format="/warn:%s", value=str(ctx.attr.warn))
 
-  paramfilepath = name+extension+".param"
-  paramfile = dotnet.declare_file(dotnet, path=paramfilepath)
+    # /modulename:<string> only used for modules
+    #libdirs = _get_libdirs(depinfo.dlls)
+    #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
 
-  dotnet.actions.write(output = paramfile, content = runner_args)
+    # /lib:dir1,[dir1]
+    #if libdirs:
+    #  args.add(format="/lib:%s", value=libdirs)
 
-  deps_files = _map_dep(deps)
-  dotnet.actions.run(
-      inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
-      outputs = [result] + ([pdb] if pdb else []),
-      executable = dotnet.runner,
-      arguments = [dotnet.mcs.path, "@"+paramfile.path],
-      mnemonic = "CoreCompile",
-      progress_message = (
-          "Compiling " + dotnet.label.package + ":" + dotnet.label.name))
+    if deps and len(deps) > 0:
+        args.add(deps, format = "/reference:%s", map_fn = _map_dep)
 
-  extra = depset(direct = [result] + [dotnet.stdlib] + ([pdb] if pdb else []), transitive = [t.files for t in data] if data else [])
-  direct = extra.to_list()   
-  runfiles = depset(direct = direct, transitive = [a[DotnetLibrary].runfiles for a in deps])
+    args.add(dotnet.stdlib, format = "/reference:%s")
 
-  return dotnet.new_library(
-    dotnet = dotnet, 
-    name = name, 
-    deps = deps, 
-    transitive = transitive,
-    result = result,
-    pdb = pdb,
-    runfiles=runfiles)
+    if defines and len(defines) > 0:
+        args.add(defines, format = "/define:%s")
 
+    if unsafe:
+        args.add("/unsafe")
+
+    if keyfile:
+        args.add("-keyfile:" + keyfile.files.to_list()[0].path)
+
+    # /debug
+    #debug = ctx.var.get("BINMODE", "") == "-dbg"
+    #if debug:
+    #  args.add("/debug")
+
+    # /warnaserror
+    # TODO(jeremy): /define:name[;name2]
+
+    if resources and len(resources) > 0:
+        args.add(resources, format = "/resource:%s", map_fn = _map_resource)
+
+    # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
+
+    # /main:class
+    #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
+    #  args.add(format="/main:%s", value=ctx.attr.main_class)
+
+    #args.add(format="/resource:%s", value=ctx.files.resources)
+
+    # TODO(jwall): /parallel
+
+    return args
+
+def emit_assembly_core(
+        dotnet,
+        name,
+        srcs,
+        deps = None,
+        out = None,
+        resources = None,
+        executable = True,
+        defines = None,
+        unsafe = False,
+        data = None,
+        keyfile = None):
+    """See dotnet/toolchains.rst#binary for full documentation."""
+
+    if name == "" and out == None:
+        fail("either name or out must be set")
+
+    if not out:
+        if executable:
+            extension = ".exe"
+        else:
+            extension = ".dll"
+        result = dotnet.declare_file(dotnet, path = name + extension)
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
+        extension = ""
+
+    if dotnet.debug:
+        pdb = dotnet.declare_file(dotnet, path = name + ".pdb")
+    else:
+        pdb = None
+
+    deps_libraries = [d[DotnetLibrary] for d in deps]
+    transitive = depset(direct = deps, transitive = [d[DotnetLibrary].transitive for d in deps])
+
+    runner_args = _make_runner_arglist(dotnet, transitive.to_list(), resources, result, pdb, executable, defines, unsafe, keyfile)
+
+    attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
+    runner_args.add(attr_srcs)
+
+    runner_args.set_param_file_format("multiline")
+
+    paramfilepath = name + extension + ".param"
+    paramfile = dotnet.declare_file(dotnet, path = paramfilepath)
+
+    dotnet.actions.write(output = paramfile, content = runner_args)
+
+    deps_files = _map_dep(deps)
+    dotnet.actions.run(
+        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
+        outputs = [result] + ([pdb] if pdb else []),
+        executable = dotnet.runner,
+        arguments = [dotnet.mcs.path, "@" + paramfile.path],
+        mnemonic = "CoreCompile",
+        progress_message = (
+            "Compiling " + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
+
+    extra = depset(direct = [result] + [dotnet.stdlib] + ([pdb] if pdb else []), transitive = [t.files for t in data] if data else [])
+    direct = extra.to_list()
+    runfiles = depset(direct = direct, transitive = [a[DotnetLibrary].runfiles for a in deps])
+
+    return dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        result = result,
+        pdb = pdb,
+        runfiles = runfiles,
+    )

--- a/dotnet/private/actions/assembly_net.bzl
+++ b/dotnet/private/actions/assembly_net.bzl
@@ -1,164 +1,165 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
     "DotnetResource",
 )
 
-
 def _map_dep(deps):
-  return [d[DotnetLibrary].result for d in deps]
+    return [d[DotnetLibrary].result for d in deps]
 
 def _map_resource(resources):
-  return [d[DotnetResource].result.path + "," + d[DotnetResource].identifier for d in resources]
+    return [d[DotnetResource].result.path + "," + d[DotnetResource].identifier for d in resources]
 
 def _make_runner_arglist(dotnet, deps, resources, output, pdb, executable, defines, unsafe, keyfile):
-  args = dotnet.actions.args()
+    args = dotnet.actions.args()
 
-  # /out:<file>
-  args.add(output.path, format="/out:%s")
+    # /out:<file>
+    args.add(output.path, format = "/out:%s")
 
-  if executable:
-    target = "exe"
-  else:
-    target = "library"
-
-  # /target (exe for binary, library for lib, module for module)
-  args.add(target, format="/target:%s")
-
-  args.add("/fullpaths")
-  args.add("/nostdlib")
-  args.add("/langversion:latest")
-  args.add("/nologo")
-
-  if pdb:
-    args.add("-debug:full")
-    args.add("-pdb:" + pdb.path)
-
-  # /warn
-  #args.add(format="/warn:%s", value=str(ctx.attr.warn))
-
-  # /modulename:<string> only used for modules
-  #libdirs = _get_libdirs(depinfo.dlls)
-  #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
-
-  # /lib:dir1,[dir1]
-  #if libdirs:
-  #  args.add(format="/lib:%s", value=libdirs)
-
-  if deps and len(deps)>0:
-    args.add(deps, format="/reference:%s", map_fn=_map_dep)
-
-  args.add(dotnet.stdlib, format="/reference:%s")
-
-  if defines and len(defines)>0:
-    args.add(defines, format="/define:%s")
-
-  if unsafe:
-    args.add("/unsafe")
-
-  if keyfile:
-    args.add("-keyfile:" + keyfile.files.to_list()[0].path)
-
-  # /debug
-  #debug = ctx.var.get("BINMODE", "") == "-dbg"
-  #if debug:
-  #  args.add("/debug")
-
-  # /warnaserror
-  # TODO(jeremy): /define:name[;name2]
-
-  if resources and len(resources)>0:
-    args.add(resources, format="/resource:%s", map_fn=_map_resource)
-
-  # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
-
-  # /main:class
-  #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
-  #  args.add(format="/main:%s", value=ctx.attr.main_class)
-
-  #args.add(format="/resource:%s", value=ctx.files.resources)
-
-  # TODO(jwall): /parallel
-
-  return args
-
-def emit_assembly_net(dotnet,
-    name = "",
-    srcs = None,
-    deps = None,
-    out = None,
-    resources = None,
-    executable = True,
-    defines = None,
-    unsafe = False,
-    data = None,
-    keyfile = None):
-  """See dotnet/toolchains.rst#binary for full documentation."""
-
-  if name == "" and out == None:
-    fail("either name or out must be set")
-
-  if not out:
     if executable:
-      extension = ".exe"
+        target = "exe"
     else:
-      extension = ".dll"
-    result = dotnet.declare_file(dotnet, path=name+extension)
-  else:
-    result = dotnet.declare_file(dotnet, path=out)  
-    extension = ""
-    
-  if dotnet.debug:
-    pdb = dotnet.declare_file(dotnet, path=name+".pdb")
-  else:
-    pdb = None
+        target = "library"
 
-  runner_args = _make_runner_arglist(dotnet, deps, resources, result, pdb, executable, defines, unsafe, keyfile)
+    # /target (exe for binary, library for lib, module for module)
+    args.add(target, format = "/target:%s")
 
-  attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
-  runner_args.add(attr_srcs)
+    args.add("/fullpaths")
+    args.add("/nostdlib")
+    args.add("/langversion:latest")
+    args.add("/nologo")
 
-  runner_args.set_param_file_format("multiline")
+    if pdb:
+        args.add("-debug:full")
+        args.add("-pdb:" + pdb.path)
 
-  # Use a "response file" to pass arguments to csc.
-  # Windows has a max command-line length of around 32k bytes. The default for
-  # Args is to spill to param files if the length of the executable, params
-  # and spaces between them sum to that number. Unfortunately the math doesn't
-  # work out exactly like that on Windows (e.g. there is also a null
-  # terminator, escaping.) For now, setting use_always to True is the
-  # conservative option. Long command lines are probable with C# due to
-  # organizing files by namespace.
-  paramfilepath = name+extension+".param"
-  paramfile = dotnet.declare_file(dotnet, path=paramfilepath)
+    # /warn
+    #args.add(format="/warn:%s", value=str(ctx.attr.warn))
 
-  dotnet.actions.write(output = paramfile, content = runner_args)
+    # /modulename:<string> only used for modules
+    #libdirs = _get_libdirs(depinfo.dlls)
+    #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
 
-  deps_files = _map_dep(deps)
-  dotnet.actions.run(
-      inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
-      outputs = [result] + ([pdb] if pdb else []),
-      executable = dotnet.mcs,
-      arguments = ["@"+paramfile.path],
-      mnemonic = "NetCompile",
-      progress_message = (
-          "Compiling " + dotnet.label.package + ":" + dotnet.label.name))
+    # /lib:dir1,[dir1]
+    #if libdirs:
+    #  args.add(format="/lib:%s", value=libdirs)
 
-  extra = [] if data == None else [d.files for d in data]
-  runfiles = depset(direct=[result] + [dotnet.stdlib] + ([pdb] if pdb else []), transitive=[d[DotnetLibrary].runfiles for d in deps] + extra)
-  transitive = depset(direct=deps, transitive=[a[DotnetLibrary].transitive for a in deps])
+    if deps and len(deps) > 0:
+        args.add(deps, format = "/reference:%s", map_fn = _map_dep)
 
-  return dotnet.new_library(
-    dotnet = dotnet, 
-    name = name, 
-    deps = deps, 
-    transitive = transitive,
-    result = result,
-    pdb = pdb,
-    runfiles=runfiles)
+    args.add(dotnet.stdlib, format = "/reference:%s")
 
+    if defines and len(defines) > 0:
+        args.add(defines, format = "/define:%s")
+
+    if unsafe:
+        args.add("/unsafe")
+
+    if keyfile:
+        args.add("-keyfile:" + keyfile.files.to_list()[0].path)
+
+    # /debug
+    #debug = ctx.var.get("BINMODE", "") == "-dbg"
+    #if debug:
+    #  args.add("/debug")
+
+    # /warnaserror
+    # TODO(jeremy): /define:name[;name2]
+
+    if resources and len(resources) > 0:
+        args.add(resources, format = "/resource:%s", map_fn = _map_resource)
+
+    # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
+
+    # /main:class
+    #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
+    #  args.add(format="/main:%s", value=ctx.attr.main_class)
+
+    #args.add(format="/resource:%s", value=ctx.files.resources)
+
+    # TODO(jwall): /parallel
+
+    return args
+
+def emit_assembly_net(
+        dotnet,
+        name = "",
+        srcs = None,
+        deps = None,
+        out = None,
+        resources = None,
+        executable = True,
+        defines = None,
+        unsafe = False,
+        data = None,
+        keyfile = None):
+    """See dotnet/toolchains.rst#binary for full documentation."""
+
+    if name == "" and out == None:
+        fail("either name or out must be set")
+
+    if not out:
+        if executable:
+            extension = ".exe"
+        else:
+            extension = ".dll"
+        result = dotnet.declare_file(dotnet, path = name + extension)
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
+        extension = ""
+
+    if dotnet.debug:
+        pdb = dotnet.declare_file(dotnet, path = name + ".pdb")
+    else:
+        pdb = None
+
+    runner_args = _make_runner_arglist(dotnet, deps, resources, result, pdb, executable, defines, unsafe, keyfile)
+
+    attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
+    runner_args.add(attr_srcs)
+
+    runner_args.set_param_file_format("multiline")
+
+    # Use a "response file" to pass arguments to csc.
+    # Windows has a max command-line length of around 32k bytes. The default for
+    # Args is to spill to param files if the length of the executable, params
+    # and spaces between them sum to that number. Unfortunately the math doesn't
+    # work out exactly like that on Windows (e.g. there is also a null
+    # terminator, escaping.) For now, setting use_always to True is the
+    # conservative option. Long command lines are probable with C# due to
+    # organizing files by namespace.
+    paramfilepath = name + extension + ".param"
+    paramfile = dotnet.declare_file(dotnet, path = paramfilepath)
+
+    dotnet.actions.write(output = paramfile, content = runner_args)
+
+    deps_files = _map_dep(deps)
+    dotnet.actions.run(
+        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
+        outputs = [result] + ([pdb] if pdb else []),
+        executable = dotnet.mcs,
+        arguments = ["@" + paramfile.path],
+        mnemonic = "NetCompile",
+        progress_message = (
+            "Compiling " + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
+
+    extra = [] if data == None else [d.files for d in data]
+    runfiles = depset(direct = [result] + [dotnet.stdlib] + ([pdb] if pdb else []), transitive = [d[DotnetLibrary].runfiles for d in deps] + extra)
+    transitive = depset(direct = deps, transitive = [a[DotnetLibrary].transitive for a in deps])
+
+    return dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        result = result,
+        pdb = pdb,
+        runfiles = runfiles,
+    )

--- a/dotnet/private/actions/com_ref_net.bzl
+++ b/dotnet/private/actions/com_ref_net.bzl
@@ -1,56 +1,69 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
 
-def _make_runner_arglist(dotnet, guid, major_version, minor_version, 
-            lcid, platform, namespace, output):
-  args = dotnet.actions.args()
+def _make_runner_arglist(
+        dotnet,
+        guid,
+        major_version,
+        minor_version,
+        lcid,
+        platform,
+        namespace,
+        output):
+    args = dotnet.actions.args()
 
-  args.add(dotnet.tlbimp)
-  args.add(guid)
-  args.add(str(major_version))
-  args.add(str(minor_version))
-  args.add(str(lcid))
-  args.add(platform)
-  args.add(namespace)
-  args.add(output, format = "%s")
+    args.add(dotnet.tlbimp)
+    args.add(guid)
+    args.add(str(major_version))
+    args.add(str(minor_version))
+    args.add(str(lcid))
+    args.add(platform)
+    args.add(namespace)
+    args.add(output, format = "%s")
 
-  return args
+    return args
 
-def emit_com_ref_net(dotnet,
-    name = "",
-    guid = None,
-    major_version = None,
-    minor_version = None,
-    lcid = None,
-    platform = None,
-    namespace = None,
-    out = None):
+def emit_com_ref_net(
+        dotnet,
+        name = "",
+        guid = None,
+        major_version = None,
+        minor_version = None,
+        lcid = None,
+        platform = None,
+        namespace = None,
+        out = None):
+    if name == "" and out == None:
+        fail("either name or out must be set")
 
-  if name == "" and out == None:
-    fail("either name or out must be set")
+    if not out:
+        result = dotnet.declare_file(dotnet, path = name + ".dll")
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
 
-  if not out:
-    result = dotnet.declare_file(dotnet, path=name+".dll")
-  else:
-    result = dotnet.declare_file(dotnet, path=out)
+    args = _make_runner_arglist(
+        dotnet,
+        guid,
+        major_version,
+        minor_version,
+        lcid,
+        platform,
+        namespace,
+        result,
+    )
 
-  args = _make_runner_arglist(dotnet, guid, major_version, minor_version, 
-            lcid, platform, namespace, result)
-
-  command = r'''tlbimp=$1
+    command = r'''tlbimp=$1
 guid=$2
 major_version=$3
 minor_version=$4
@@ -65,12 +78,14 @@ out="$(echo $output | sed 's/\//\\/g')"
 params="${tlbimp} ${result/\%SystemRoot\%/C:\\Windows} /out:${out} /namespace:${namespace}"
 $params'''
 
-  dotnet.actions.run_shell(
-      outputs = [result],
-      command = command,
-      arguments = [args],
-      mnemonic = "NetComRefGen",
-      progress_message = (
-          "Generating com wrapper" + dotnet.label.package + ":" + dotnet.label.name))
+    dotnet.actions.run_shell(
+        outputs = [result],
+        command = command,
+        arguments = [args],
+        mnemonic = "NetComRefGen",
+        progress_message = (
+            "Generating com wrapper" + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
 
-  return result
+    return result

--- a/dotnet/private/actions/resx.bzl
+++ b/dotnet/private/actions/resx.bzl
@@ -1,68 +1,67 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
 
-
 def _make_runner_arglist(dotnet, source, output):
-  args = dotnet.actions.args()
+    args = dotnet.actions.args()
 
-  args.add(dotnet.resgen.path)
-  args.add(source.files, format = "%s")
+    args.add(dotnet.resgen.path)
+    args.add(source.files, format = "%s")
 
-  return args
+    return args
 
-def emit_resx(dotnet,
-    name = "",
-    src = None,
-    identifier = None,
-    out = None,
-    customresgen = None):
+def emit_resx(
+        dotnet,
+        name = "",
+        src = None,
+        identifier = None,
+        out = None,
+        customresgen = None):
+    if name == "" and out == None:
+        fail("either name or out must be set")
 
-  if name == "" and out == None:
-    fail("either name or out must be set")
+    if not out:
+        result = dotnet.declare_file(dotnet, path = name + ".resources")
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
 
-  if not out:
-    result = dotnet.declare_file(dotnet, path=name+".resources")
-  else:
-    result = dotnet.declare_file(dotnet, path=out)  
+    # Unfortunately, resgen always produces the output in the same directory as the input file
+    # Therefore we have to copy the source file to the target directory
+    copied_source = dotnet.declare_file(dotnet, path = paths.replace_extension(result.basename, ".resx"))
 
-  # Unfortunately, resgen always produces the output in the same directory as the input file
-  # Therefore we have to copy the source file to the target directory
-  copied_source = dotnet.declare_file(dotnet, path=paths.replace_extension(result.basename, ".resx"))
+    dotnet.actions.run_shell(
+        inputs = src.files,
+        outputs = [copied_source],
+        mnemonic = "MonoResxCopySource",
+        command = "cp {} {}".format(src.files.to_list()[0].path, copied_source.path),
+    )
 
-  dotnet.actions.run_shell(
-      inputs = src.files,
-      outputs = [copied_source],
-      mnemonic = "MonoResxCopySource",
-      command = "cp {} {}".format(src.files.to_list()[0].path, copied_source.path),      
-  )
+    args = _make_runner_arglist(dotnet, src, result)
 
-  args = _make_runner_arglist(dotnet, src, result)
+    dotnet.actions.run(
+        inputs = [copied_source],
+        outputs = [result],
+        executable = dotnet.runner,
+        arguments = [dotnet.resgen.path, copied_source.path],
+        mnemonic = "MonoResxCompile",
+        progress_message = (
+            "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
 
-  dotnet.actions.run(
-      inputs = [copied_source],
-      outputs = [result],
-      executable = dotnet.runner,
-      arguments = [dotnet.resgen.path, copied_source.path],
-      mnemonic = "MonoResxCompile",
-      progress_message = (
-          "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name))
-
-  return dotnet.new_resource(
-    dotnet = dotnet, 
-    name = name, 
-    result = result,
-    identifier = identifier)
-
+    return dotnet.new_resource(
+        dotnet = dotnet,
+        name = name,
+        result = result,
+        identifier = identifier,
+    )

--- a/dotnet/private/actions/resx_core.bzl
+++ b/dotnet/private/actions/resx_core.bzl
@@ -1,64 +1,63 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
 
-
 def _make_runner_arglist(dotnet, source, output, resgen):
-  args = dotnet.actions.args()
+    args = dotnet.actions.args()
 
-  args.add(resgen)
-  args.add(source.files, format = "%s")
-  args.add(output)
+    args.add(resgen)
+    args.add(source.files, format = "%s")
+    args.add(output)
 
-  return args
+    return args
 
-def emit_resx_core(dotnet,
-    name = "",
-    src = None,
-    identifier = None,
-    out = None,
-    customresgen = None):
+def emit_resx_core(
+        dotnet,
+        name = "",
+        src = None,
+        identifier = None,
+        out = None,
+        customresgen = None):
+    if name == "" and out == None:
+        fail("either name or out must be set")
 
-  if name == "" and out == None:
-    fail("either name or out must be set")
+    if not out:
+        result = dotnet.declare_file(dotnet, path = name + ".resources")
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
 
-  if not out:
-    result = dotnet.declare_file(dotnet, path=name+".resources")
-  else:
-    result = dotnet.declare_file(dotnet, path=out)  
+    args = _make_runner_arglist(dotnet, src, result, customresgen.files_to_run.executable.path)
 
-  args = _make_runner_arglist(dotnet, src, result, customresgen.files_to_run.executable.path)
+    # We use the command to extrace shell path and force runfiles creation
+    resolve = dotnet._ctx.resolve_command(command = customresgen.files_to_run.executable.path, tools = [customresgen])
 
-  # We use the command to extrace shell path and force runfiles creation
-  resolve = dotnet._ctx.resolve_command(command=customresgen.files_to_run.executable.path, tools=[customresgen])
+    dotnet.actions.run(
+        inputs = src.files + resolve[0],
+        tools = customresgen.files,
+        outputs = [result],
+        executable = resolve[1][0],
+        arguments = [args],
+        env = {"RUNFILES_MANIFEST_FILE": customresgen.files_to_run.runfiles_manifest.path},
+        mnemonic = "CoreResxCompile",
+        input_manifests = resolve[2],
+        progress_message = (
+            "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
 
-  dotnet.actions.run(
-      inputs = src.files + resolve[0],
-      tools = customresgen.files,
-      outputs = [result],
-      executable = resolve[1][0],
-      arguments = [args],
-      env = {"RUNFILES_MANIFEST_FILE":customresgen.files_to_run.runfiles_manifest.path},
-      mnemonic = "CoreResxCompile",
-      input_manifests = resolve[2],
-      progress_message = (
-          "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name))
-
-  return dotnet.new_resource(
-    dotnet = dotnet, 
-    name = name, 
-    result = result,
-    identifier = identifier)
-
+    return dotnet.new_resource(
+        dotnet = dotnet,
+        name = name,
+        result = result,
+        identifier = identifier,
+    )

--- a/dotnet/private/actions/resx_net.bzl
+++ b/dotnet/private/actions/resx_net.bzl
@@ -1,57 +1,56 @@
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "as_iterable",
-    "sets"
+    "sets",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
 
-
 def _make_runner_arglist(dotnet, source, output):
-  args = dotnet.actions.args()
+    args = dotnet.actions.args()
 
-  args.add(source.files, format = "%s")
-  args.add(output)
+    args.add(source.files, format = "%s")
+    args.add(output)
 
-  return args
+    return args
 
-def emit_resx_net(dotnet,
-    name = "",
-    src = None,
-    identifier = None,
-    out = None,
-    customresgen = None):
+def emit_resx_net(
+        dotnet,
+        name = "",
+        src = None,
+        identifier = None,
+        out = None,
+        customresgen = None):
+    if name == "" and out == None:
+        fail("either name or out must be set")
 
-  if name == "" and out == None:
-    fail("either name or out must be set")
+    if not out:
+        result = dotnet.declare_file(dotnet, path = name + ".resources")
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
 
-  if not out:
-    result = dotnet.declare_file(dotnet, path=name+".resources")
-  else:
-    result = dotnet.declare_file(dotnet, path=out)  
+    args = _make_runner_arglist(dotnet, src, result)
 
-  args = _make_runner_arglist(dotnet, src, result)
+    dotnet.actions.run(
+        inputs = src.files,
+        outputs = [result],
+        executable = dotnet.resgen,
+        arguments = [args],
+        mnemonic = "NetResxCompile",
+        progress_message = (
+            "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
 
-  dotnet.actions.run(
-      inputs = src.files,
-      outputs = [result],
-      executable = dotnet.resgen,
-      arguments = [args],
-      mnemonic = "NetResxCompile",
-      progress_message = (
-          "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name))
-
-  return dotnet.new_resource(
-    dotnet = dotnet, 
-    name = name, 
-    result = result,
-    identifier = identifier)
-
+    return dotnet.new_resource(
+        dotnet = dotnet,
+        name = name,
+        result = result,
+        identifier = identifier,
+    )

--- a/dotnet/private/common.bzl
+++ b/dotnet/private/common.bzl
@@ -3,42 +3,42 @@ load("//dotnet/private:skylib/lib/sets.bzl", "sets")
 load("//dotnet/private:skylib/lib/dicts.bzl", "dicts")
 
 def executable_extension(ctx):
-  extension = ""
-  if ctx.os.name.startswith('windows'):
-    extension = ".exe"
-  return extension
+    extension = ""
+    if ctx.os.name.startswith("windows"):
+        extension = ".exe"
+    return extension
 
 def bat_extension(ctx):
-  extension = ""
-  if ctx.os.name.startswith('windows'):
-    extension = ".bat"
-  return extension
+    extension = ""
+    if ctx.os.name.startswith("windows"):
+        extension = ".bat"
+    return extension
 
 def as_iterable(v):
-  if type(v) == "list":
-    return v
-  if type(v) == "tuple":
-    return v
-  if type(v) == "depset":
-    return v.to_list()
-  fail("as_iterator failed on {}".format(v))
+    if type(v) == "list":
+        return v
+    if type(v) == "tuple":
+        return v
+    if type(v) == "depset":
+        return v.to_list()
+    fail("as_iterator failed on {}".format(v))
 
 def env_execute(ctx, arguments, environment = {}, **kwargs):
-  """env_executes a command in a repository context. It prepends "env -i"
-  to "arguments" before calling "ctx.execute".
+    """env_executes a command in a repository context. It prepends "env -i"
+    to "arguments" before calling "ctx.execute".
 
-  Variables that aren't explicitly mentioned in "environment"
-  are removed from the environment. This should be preferred to "ctx.execut"e
-  in most situations.
-  """
-  if ctx.os.name.startswith('windows'):
-    return ctx.execute(arguments, environment=environment, **kwargs)
-  env_args = ["env", "-i"]
-  environment = dict(environment)
-  for var in ["TMP", "TMPDIR"]:
-    if var in ctx.os.environ and not var in environment:
-      environment[var] = ctx.os.environ[var]
-  for k, v in environment.items():
-    env_args.append("%s=%s" % (k, v))
-  arguments = env_args + arguments
-  return ctx.execute(arguments, **kwargs)
+    Variables that aren't explicitly mentioned in "environment"
+    are removed from the environment. This should be preferred to "ctx.execut"e
+    in most situations.
+    """
+    if ctx.os.name.startswith("windows"):
+        return ctx.execute(arguments, environment = environment, **kwargs)
+    env_args = ["env", "-i"]
+    environment = dict(environment)
+    for var in ["TMP", "TMPDIR"]:
+        if var in ctx.os.environ and not var in environment:
+            environment[var] = ctx.os.environ[var]
+    for k, v in environment.items():
+        env_args.append("%s=%s" % (k, v))
+    arguments = env_args + arguments
+    return ctx.execute(arguments, **kwargs)

--- a/dotnet/private/context.bzl
+++ b/dotnet/private/context.bzl
@@ -3,175 +3,171 @@ load(
     "DotnetLibrary",
     "DotnetResource",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
 
-
 DotnetContext = provider()
 
-
 def _declare_file(dotnet, path = None, ext = None):
-  result = path if path else dotnet._ctx.label.name
-  if ext:
-    result += ext
-  return dotnet.actions.declare_file(result)
+    result = path if path else dotnet._ctx.label.name
+    if ext:
+        result += ext
+    return dotnet.actions.declare_file(result)
 
+def _new_library(dotnet, name = None, deps = None, transitive = None, result = None, pdb = None, runfiles = None, **kwargs):
+    return DotnetLibrary(
+        name = dotnet.label.name if not name else name,
+        label = dotnet.label,
+        deps = deps,
+        transitive = transitive,
+        result = result,
+        pdb = pdb,
+        runfiles = runfiles,
+        **kwargs
+    )
 
-def _new_library(dotnet, name=None, deps=None, transitive=None, result=None, pdb=None, runfiles=None,**kwargs):
-  return DotnetLibrary(
-      name = dotnet.label.name if not name else name,
-      label = dotnet.label,
-      deps = deps,
-      transitive = transitive,
-      result=result,
-      pdb=pdb,
-      runfiles=runfiles,
-      **kwargs
-  )
+def _new_resource(dotnet, name, result, identifier = None, **kwargs):
+    return DotnetResource(
+        name = name,
+        label = dotnet.label,
+        result = result,
+        identifier = result.basename if not identifier else identifier,
+        **kwargs
+    )
 
-def _new_resource(dotnet, name, result, identifier=None, **kwargs):
-  return DotnetResource(
-      name = name,
-      label = dotnet.label,
-      result = result,
-      identifier = result.basename if not identifier else identifier,
-      **kwargs
-  )
+def dotnet_context(ctx, attr = None):
+    if not attr:
+        attr = ctx.attr
 
-def dotnet_context(ctx, attr=None):
-  if not attr:
-    attr = ctx.attr
+    context_data = attr._dotnet_context_data
+    toolchain = ctx.toolchains[context_data._toolchain_type]
 
-  context_data = attr._dotnet_context_data 
-  toolchain = ctx.toolchains[context_data._toolchain_type]
+    ext = ""
+    if toolchain.default_dotnetos == "windows":
+        ext = ".exe"
 
-  ext = ""
-  if toolchain.default_dotnetos == "windows":
-    ext = ".exe"
+    # Handle empty toolchain for .NET on linux and osx
+    if toolchain.get_dotnet_runner == None:
+        runner = None
+        mcs = None
+        stdlib = None
+        resgen = None
+        tlbimp = None
+    else:
+        runner = toolchain.get_dotnet_runner(context_data, ext)
+        mcs = toolchain.get_dotnet_mcs(context_data)
+        stdlib = toolchain.get_dotnet_stdlib(context_data)
+        resgen = toolchain.get_dotnet_resgen(context_data)
+        tlbimp = toolchain.get_dotnet_tlbimp(context_data)
 
-  # Handle empty toolchain for .NET on linux and osx
-  if toolchain.get_dotnet_runner == None:
-    runner = None
-    mcs = None
-    stdlib = None
-    resgen = None
-    tlbimp = None
-  else:
-    runner = toolchain.get_dotnet_runner(context_data, ext)
-    mcs = toolchain.get_dotnet_mcs(context_data)
-    stdlib = toolchain.get_dotnet_stdlib(context_data)
-    resgen = toolchain.get_dotnet_resgen(context_data)
-    tlbimp = toolchain.get_dotnet_tlbimp(context_data)
-
-  return DotnetContext(
-      # Fields
-      label = ctx.label,
-      toolchain = toolchain,
-      actions = ctx.actions,
-      assembly = toolchain.actions.assembly,
-      resx = toolchain.actions.resx,
-      com_ref = toolchain.actions.com_ref,
-      stdlib_byname = toolchain.actions.stdlib_byname,
-      exe_extension = ext,
-      runner = runner,
-      mcs = mcs,
-      stdlib = stdlib,
-      resgen = resgen,
-      tlbimp = tlbimp,
-      declare_file = _declare_file,
-      new_library = _new_library,
-      new_resource = _new_resource,
-      workspace_name = ctx.workspace_name,
-      libVersion = context_data._libVersion,
-      lib = context_data._lib,
-      shared = context_data._shared,
-      debug = ctx.var["COMPILATION_MODE"] == "dbg",
-      _ctx = ctx
-  )
+    return DotnetContext(
+        # Fields
+        label = ctx.label,
+        toolchain = toolchain,
+        actions = ctx.actions,
+        assembly = toolchain.actions.assembly,
+        resx = toolchain.actions.resx,
+        com_ref = toolchain.actions.com_ref,
+        stdlib_byname = toolchain.actions.stdlib_byname,
+        exe_extension = ext,
+        runner = runner,
+        mcs = mcs,
+        stdlib = stdlib,
+        resgen = resgen,
+        tlbimp = tlbimp,
+        declare_file = _declare_file,
+        new_library = _new_library,
+        new_resource = _new_resource,
+        workspace_name = ctx.workspace_name,
+        libVersion = context_data._libVersion,
+        lib = context_data._lib,
+        shared = context_data._shared,
+        debug = ctx.var["COMPILATION_MODE"] == "dbg",
+        _ctx = ctx,
+    )
 
 def _dotnet_context_data(ctx):
-  return struct(
-      _mcs_bin = ctx.attr._mcs_bin,
-      _mono_bin = ctx.attr._mono_bin,
-      _lib = ctx.attr._lib,
-      _tools = ctx.attr._tools,
-      _shared = ctx.attr._shared,
-      _host = ctx.attr._host,
-      _libVersion = ctx.attr._libVersion,
-      _toolchain_type = ctx.attr._toolchain_type,
-  )
+    return struct(
+        _mcs_bin = ctx.attr._mcs_bin,
+        _mono_bin = ctx.attr._mono_bin,
+        _lib = ctx.attr._lib,
+        _tools = ctx.attr._tools,
+        _shared = ctx.attr._shared,
+        _host = ctx.attr._host,
+        _libVersion = ctx.attr._libVersion,
+        _toolchain_type = ctx.attr._toolchain_type,
+    )
 
 dotnet_context_data = rule(
     _dotnet_context_data,
     attrs = {
         "_mcs_bin": attr.label(
             allow_files = True,
-            default="@dotnet_sdk//:mcs_bin",
+            default = "@dotnet_sdk//:mcs_bin",
         ),
         "_mono_bin": attr.label(
             allow_files = True,
-            default="@dotnet_sdk//:mono_bin",
+            default = "@dotnet_sdk//:mono_bin",
         ),
         "_lib": attr.label(
             allow_files = True,
-            default="@dotnet_sdk//:lib",
+            default = "@dotnet_sdk//:lib",
         ),
         "_tools": attr.label(
             allow_files = True,
-            default="@net_sdk//:lib",
+            default = "@net_sdk//:lib",
         ),
         "_shared": attr.label(
             allow_files = True,
-            default="@dotnet_sdk//:lib",
+            default = "@dotnet_sdk//:lib",
         ),
         "_host": attr.label(
             allow_files = True,
-            default="@dotnet_sdk//:lib",
+            default = "@dotnet_sdk//:lib",
         ),
         "_libVersion": attr.string(
-            default="4.5",
+            default = "4.5",
         ),
         "_toolchain_type": attr.string(
-            default="@io_bazel_rules_dotnet//dotnet:toolchain",
+            default = "@io_bazel_rules_dotnet//dotnet:toolchain",
         ),
     },
 )
-  
+
 core_context_data = rule(
     _dotnet_context_data,
     attrs = {
         "_mcs_bin": attr.label(
             allow_files = True,
-            default="@core_sdk//:mcs_bin",
+            default = "@core_sdk//:mcs_bin",
         ),
         "_mono_bin": attr.label(
             allow_files = True,
-            default="@core_sdk//:mono_bin",
+            default = "@core_sdk//:mono_bin",
         ),
         "_lib": attr.label(
             allow_files = True,
-            default="@core_sdk//:lib",
+            default = "@core_sdk//:lib",
         ),
         "_tools": attr.label(
             allow_files = True,
-            default="@net_sdk//:lib",
+            default = "@net_sdk//:lib",
         ),
         "_shared": attr.label(
             allow_files = True,
-            default="@core_sdk//:shared",
+            default = "@core_sdk//:shared",
         ),
         "_host": attr.label(
             allow_files = True,
-            default="@core_sdk//:host",
+            default = "@core_sdk//:host",
         ),
         "_libVersion": attr.string(
-            default="",
+            default = "",
         ),
         "_toolchain_type": attr.string(
-            default="@io_bazel_rules_dotnet//dotnet:toolchain_core",
+            default = "@io_bazel_rules_dotnet//dotnet:toolchain_core",
         ),
     },
 )
@@ -181,33 +177,33 @@ net_context_data = rule(
     attrs = {
         "_mcs_bin": attr.label(
             allow_files = True,
-            default="@net_sdk//:mcs_bin",
+            default = "@net_sdk//:mcs_bin",
         ),
         "_mono_bin": attr.label(
             allow_files = True,
-            default="@net_sdk//:mono_bin",
+            default = "@net_sdk//:mono_bin",
         ),
         "_lib": attr.label(
             allow_files = True,
-            default="@net_sdk//:lib",
+            default = "@net_sdk//:lib",
         ),
         "_tools": attr.label(
             allow_files = True,
-            default="@net_sdk//:tools",
+            default = "@net_sdk//:tools",
         ),
         "_shared": attr.label(
             allow_files = True,
-            default="@net_sdk//:lib",
+            default = "@net_sdk//:lib",
         ),
         "_host": attr.label(
             allow_files = True,
-            default="@net_sdk//:mcs_bin",
+            default = "@net_sdk//:mcs_bin",
         ),
         "_libVersion": attr.string(
-            default="",
+            default = "",
         ),
         "_toolchain_type": attr.string(
-            default="@io_bazel_rules_dotnet//dotnet:toolchain_net",
+            default = "@io_bazel_rules_dotnet//dotnet:toolchain_net",
         ),
     },
 )

--- a/dotnet/private/dotnet_toolchain.bzl
+++ b/dotnet/private/dotnet_toolchain.bzl
@@ -19,95 +19,93 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
-
 load("@io_bazel_rules_dotnet//dotnet/private:actions/assembly.bzl", "emit_assembly")
 load("@io_bazel_rules_dotnet//dotnet/private:actions/resx.bzl", "emit_resx")
 
 def _get_dotnet_runner(context_data, ext):
-  for f in context_data._mono_bin.files:
-    basename = paths.basename(f.path)
-    if basename != "mono" + ext:
-      continue
-    return f
-  fail("Could not find mono executable in dotnet_sdk (mono_bin)")
-
+    for f in context_data._mono_bin.files:
+        basename = paths.basename(f.path)
+        if basename != "mono" + ext:
+            continue
+        return f
+    fail("Could not find mono executable in dotnet_sdk (mono_bin)")
 
 def _get_dotnet_mcs(context_data):
-  for f in context_data._mcs_bin.files:
-    basename = paths.basename(f.path)
-    if basename != "mcs.exe":
-      continue
-    return f
+    for f in context_data._mcs_bin.files:
+        basename = paths.basename(f.path)
+        if basename != "mcs.exe":
+            continue
+        return f
 
-  for f in context_data._lib.files:
-    basename = paths.basename(f.path)
-    if basename != "mcs.exe":
-      continue
-    return f
-  fail("Could not find mcs.exe in dotnet_sdk (mcs_bin, lib)")
+    for f in context_data._lib.files:
+        basename = paths.basename(f.path)
+        if basename != "mcs.exe":
+            continue
+        return f
+    fail("Could not find mcs.exe in dotnet_sdk (mcs_bin, lib)")
 
 def _get_dotnet_resgen(context_data):
-  for f in context_data._mcs_bin.files:
-    basename = paths.basename(f.path)
-    if basename != "resgen.exe":
-      continue
-    return f
+    for f in context_data._mcs_bin.files:
+        basename = paths.basename(f.path)
+        if basename != "resgen.exe":
+            continue
+        return f
 
-  for f in context_data._lib.files:
-    basename = paths.basename(f.path)
-    if basename != "resgen.exe":
-      continue
-    return f
+    for f in context_data._lib.files:
+        basename = paths.basename(f.path)
+        if basename != "resgen.exe":
+            continue
+        return f
 
-  fail("Could not find resgen.exe in dotnet_sdk (mcs_bin, lib)")
+    fail("Could not find resgen.exe in dotnet_sdk (mcs_bin, lib)")
 
 def _get_dotnet_tlbimp(context_data):
-  return None
+    return None
 
 def _get_dotnet_stdlib(context_data):
-  for f in context_data._lib.files:
-    basename = paths.basename(f.path)
-    if basename != "mscorlib.dll":
-      continue
-    dirname = paths.dirname(f.path)
-    if dirname.find(context_data._libVersion)==-1:
-      continue
-    return f
-  fail("Could not find mscorlib in dotnet_sdk (lib, %s)" % context_data._libVersion)
+    for f in context_data._lib.files:
+        basename = paths.basename(f.path)
+        if basename != "mscorlib.dll":
+            continue
+        dirname = paths.dirname(f.path)
+        if dirname.find(context_data._libVersion) == -1:
+            continue
+        return f
+    fail("Could not find mscorlib in dotnet_sdk (lib, %s)" % context_data._libVersion)
 
 def _get_dotnet_stdlib_byname(shared, lib, libVersion, name):
-  lname = name.lower()
-  for f in lib.files:
-    basename = paths.basename(f.path)
-    if basename.lower() != lname:
-      continue
-    dirname = paths.dirname(f.path)
-    if dirname.find(libVersion)==-1:
-      continue
-    return f
-  fail("Could not find %s in dotnet_sdk (lib)" % name)
+    lname = name.lower()
+    for f in lib.files:
+        basename = paths.basename(f.path)
+        if basename.lower() != lname:
+            continue
+        dirname = paths.dirname(f.path)
+        if dirname.find(libVersion) == -1:
+            continue
+        return f
+    fail("Could not find %s in dotnet_sdk (lib)" % name)
 
 def _dotnet_toolchain_impl(ctx):
-  return [platform_common.ToolchainInfo(
-      name = ctx.label.name,
-      default_dotnetimpl = ctx.attr.dotnetimpl,
-      default_dotnetos = ctx.attr.dotnetos,
-      default_dotnetarch = ctx.attr.dotnetarch,
-      get_dotnet_runner = _get_dotnet_runner,
-      get_dotnet_mcs = _get_dotnet_mcs,
-      get_dotnet_resgen = _get_dotnet_resgen,
-      get_dotnet_tlbimp = _get_dotnet_tlbimp,
-      get_dotnet_stdlib = _get_dotnet_stdlib,
-      actions = struct(
-          assembly = emit_assembly,
-          resx = emit_resx,
-          com_ref = None,
-          stdlib_byname = _get_dotnet_stdlib_byname,
-      ),
-      flags = struct(
-          compile = (),
-      ),
-  )]
+    return [platform_common.ToolchainInfo(
+        name = ctx.label.name,
+        default_dotnetimpl = ctx.attr.dotnetimpl,
+        default_dotnetos = ctx.attr.dotnetos,
+        default_dotnetarch = ctx.attr.dotnetarch,
+        get_dotnet_runner = _get_dotnet_runner,
+        get_dotnet_mcs = _get_dotnet_mcs,
+        get_dotnet_resgen = _get_dotnet_resgen,
+        get_dotnet_tlbimp = _get_dotnet_tlbimp,
+        get_dotnet_stdlib = _get_dotnet_stdlib,
+        actions = struct(
+            assembly = emit_assembly,
+            resx = emit_resx,
+            com_ref = None,
+            stdlib_byname = _get_dotnet_stdlib_byname,
+        ),
+        flags = struct(
+            compile = (),
+        ),
+    )]
 
 _dotnet_toolchain = rule(
     _dotnet_toolchain_impl,
@@ -119,29 +117,29 @@ _dotnet_toolchain = rule(
     },
 )
 
-def dotnet_toolchain(name, host, constraints=[], **kwargs):
-  """See dotnet/toolchains.rst#dotnet-toolchain for full documentation."""
+def dotnet_toolchain(name, host, constraints = [], **kwargs):
+    """See dotnet/toolchains.rst#dotnet-toolchain for full documentation."""
 
-  elems = host.split("_")
-  impl, os, arch = elems[0], elems[1], elems[2]
-  host_constraints = constraints + [
-    "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
-    "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
-  ]
+    elems = host.split("_")
+    impl, os, arch = elems[0], elems[1], elems[2]
+    host_constraints = constraints + [
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
+    ]
 
-  impl_name = name + "-impl"
-  _dotnet_toolchain(
-      name = impl_name,
-      dotnetimpl = impl,
-      dotnetos = os,
-      dotnetarch = arch,
-      tags = ["manual"],
-      visibility = ["//visibility:public"],
-      **kwargs
-  )
-  native.toolchain(
-      name = name,
-      toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain",
-      exec_compatible_with = host_constraints,
-      toolchain = ":"+impl_name,
-  )
+    impl_name = name + "-impl"
+    _dotnet_toolchain(
+        name = impl_name,
+        dotnetimpl = impl,
+        dotnetos = os,
+        dotnetarch = arch,
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
+    native.toolchain(
+        name = name,
+        toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain",
+        exec_compatible_with = host_constraints,
+        toolchain = ":" + impl_name,
+    )

--- a/dotnet/private/net_empty_toolchain.bzl
+++ b/dotnet/private/net_empty_toolchain.bzl
@@ -17,28 +17,27 @@ rules on other platforms. This way targets specified for incompatible platforms 
 and silently are skupped
 """
 
-
 def _net_empty_toolchain_impl(ctx):
-  return [platform_common.ToolchainInfo(
-      name = ctx.label.name,
-      default_dotnetimpl = ctx.attr.dotnetimpl,
-      default_dotnetos = ctx.attr.dotnetos,
-      default_dotnetarch = ctx.attr.dotnetarch,
-      get_dotnet_runner = None,
-      get_dotnet_mcs = None,
-      get_dotnet_resgen = None,
-      get_dotnet_tlbimp = None,
-      get_dotnet_stdlib = None,
-      actions = struct(
-          assembly = None,
-          resx = None,
-          com_ref = None,
-          stdlib_byname = None,
-      ),
-      flags = struct(
-          compile = (),
-      ),
-  )]
+    return [platform_common.ToolchainInfo(
+        name = ctx.label.name,
+        default_dotnetimpl = ctx.attr.dotnetimpl,
+        default_dotnetos = ctx.attr.dotnetos,
+        default_dotnetarch = ctx.attr.dotnetarch,
+        get_dotnet_runner = None,
+        get_dotnet_mcs = None,
+        get_dotnet_resgen = None,
+        get_dotnet_tlbimp = None,
+        get_dotnet_stdlib = None,
+        actions = struct(
+            assembly = None,
+            resx = None,
+            com_ref = None,
+            stdlib_byname = None,
+        ),
+        flags = struct(
+            compile = (),
+        ),
+    )]
 
 _net_empty_toolchain = rule(
     _net_empty_toolchain_impl,
@@ -50,29 +49,29 @@ _net_empty_toolchain = rule(
     },
 )
 
-def net_empty_toolchain(name, host, constraints=[], **kwargs):
-  """See dotnet/toolchains.rst#net-toolchain for full documentation."""
+def net_empty_toolchain(name, host, constraints = [], **kwargs):
+    """See dotnet/toolchains.rst#net-toolchain for full documentation."""
 
-  elems = host.split("_")
-  impl, os, arch = elems[0], elems[1], elems[2]
-  host_constraints = constraints + [
-    "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
-    "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
-  ]
+    elems = host.split("_")
+    impl, os, arch = elems[0], elems[1], elems[2]
+    host_constraints = constraints + [
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
+    ]
 
-  impl_name = name + "-impl"
-  _net_empty_toolchain(
-      name = impl_name,
-      dotnetimpl = impl,
-      dotnetos = os,
-      dotnetarch = arch,
-      tags = ["manual"],
-      visibility = ["//visibility:public"],
-      **kwargs
-  )
-  native.toolchain(
-      name = name,
-      toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain_net",
-      exec_compatible_with = host_constraints,
-      toolchain = ":"+impl_name,
-  )
+    impl_name = name + "-impl"
+    _net_empty_toolchain(
+        name = impl_name,
+        dotnetimpl = impl,
+        dotnetos = os,
+        dotnetarch = arch,
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
+    native.toolchain(
+        name = name,
+        toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain_net",
+        exec_compatible_with = host_constraints,
+        toolchain = ":" + impl_name,
+    )

--- a/dotnet/private/net_toolchain.bzl
+++ b/dotnet/private/net_toolchain.bzl
@@ -19,75 +19,73 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
     "paths",
 )
-
-
 load("@io_bazel_rules_dotnet//dotnet/private:actions/assembly_net.bzl", "emit_assembly_net")
 load("@io_bazel_rules_dotnet//dotnet/private:actions/resx_net.bzl", "emit_resx_net")
 load("@io_bazel_rules_dotnet//dotnet/private:actions/com_ref_net.bzl", "emit_com_ref_net")
 
 def _get_dotnet_runner(context_data, ext):
-  return None
+    return None
 
 def _get_dotnet_mcs(context_data):
-  for f in context_data._mcs_bin.files:
-    basename = paths.basename(f.path)
-    if basename != "csc.exe":
-      continue
-    return f
-  fail("Could not find csc.exe in net_sdk (mcs_bin)")
+    for f in context_data._mcs_bin.files:
+        basename = paths.basename(f.path)
+        if basename != "csc.exe":
+            continue
+        return f
+    fail("Could not find csc.exe in net_sdk (mcs_bin)")
 
 def _get_dotnet_resgen(context_data):
-  return _get_dotnet_tool(context_data, "resgen.exe")
+    return _get_dotnet_tool(context_data, "resgen.exe")
 
 def _get_dotnet_tlbimp(context_data):
-  return _get_dotnet_tool(context_data, "tlbimp.exe")
+    return _get_dotnet_tool(context_data, "tlbimp.exe")
 
 def _get_dotnet_tool(context_data, name):
-  for f in context_data._tools.files:
-    basename = paths.basename(f.path)
-    if basename.lower() != name:
-      continue
-    return f
-  fail("Could not find %s in net_sdk (tools)" % name)
+    for f in context_data._tools.files:
+        basename = paths.basename(f.path)
+        if basename.lower() != name:
+            continue
+        return f
+    fail("Could not find %s in net_sdk (tools)" % name)
 
 def _get_dotnet_stdlib(context_data):
-  for f in context_data._lib.files:
-    basename = paths.basename(f.path)
-    if basename != "mscorlib.dll":
-      continue
-    return f
-  fail("Could not find mscorlib in net_sdk (lib, %s)" % context_data._libVersion)
+    for f in context_data._lib.files:
+        basename = paths.basename(f.path)
+        if basename != "mscorlib.dll":
+            continue
+        return f
+    fail("Could not find mscorlib in net_sdk (lib, %s)" % context_data._libVersion)
 
 def _get_dotnet_stdlib_byname(shared, lib, libVersion, name):
-  lname = name.lower()
-  for f in shared.files:
-    basename = paths.basename(f.path)
-    if basename.lower() != lname:
-      continue
-    return f
-  fail("Could not find %s in net_sdk (shared)" % name)
+    lname = name.lower()
+    for f in shared.files:
+        basename = paths.basename(f.path)
+        if basename.lower() != lname:
+            continue
+        return f
+    fail("Could not find %s in net_sdk (shared)" % name)
 
 def _net_toolchain_impl(ctx):
-  return [platform_common.ToolchainInfo(
-      name = ctx.label.name,
-      default_dotnetimpl = ctx.attr.dotnetimpl,
-      default_dotnetos = ctx.attr.dotnetos,
-      default_dotnetarch = ctx.attr.dotnetarch,
-      get_dotnet_runner = _get_dotnet_runner,
-      get_dotnet_mcs = _get_dotnet_mcs,
-      get_dotnet_resgen = _get_dotnet_resgen,
-      get_dotnet_tlbimp = _get_dotnet_tlbimp,
-      get_dotnet_stdlib = _get_dotnet_stdlib,
-      actions = struct(
-          assembly = emit_assembly_net,
-          resx = emit_resx_net,
-          com_ref = emit_com_ref_net,
-          stdlib_byname = _get_dotnet_stdlib_byname,
-      ),
-      flags = struct(
-          compile = (),
-      ),
-  )]
+    return [platform_common.ToolchainInfo(
+        name = ctx.label.name,
+        default_dotnetimpl = ctx.attr.dotnetimpl,
+        default_dotnetos = ctx.attr.dotnetos,
+        default_dotnetarch = ctx.attr.dotnetarch,
+        get_dotnet_runner = _get_dotnet_runner,
+        get_dotnet_mcs = _get_dotnet_mcs,
+        get_dotnet_resgen = _get_dotnet_resgen,
+        get_dotnet_tlbimp = _get_dotnet_tlbimp,
+        get_dotnet_stdlib = _get_dotnet_stdlib,
+        actions = struct(
+            assembly = emit_assembly_net,
+            resx = emit_resx_net,
+            com_ref = emit_com_ref_net,
+            stdlib_byname = _get_dotnet_stdlib_byname,
+        ),
+        flags = struct(
+            compile = (),
+        ),
+    )]
 
 _net_toolchain = rule(
     _net_toolchain_impl,
@@ -99,29 +97,29 @@ _net_toolchain = rule(
     },
 )
 
-def net_toolchain(name, host, constraints=[], **kwargs):
-  """See dotnet/toolchains.rst#net-toolchain for full documentation."""
+def net_toolchain(name, host, constraints = [], **kwargs):
+    """See dotnet/toolchains.rst#net-toolchain for full documentation."""
 
-  elems = host.split("_")
-  impl, os, arch = elems[0], elems[1], elems[2]
-  host_constraints = constraints + [
-    "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
-    "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
-  ]
+    elems = host.split("_")
+    impl, os, arch = elems[0], elems[1], elems[2]
+    host_constraints = constraints + [
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
+    ]
 
-  impl_name = name + "-impl"
-  _net_toolchain(
-      name = impl_name,
-      dotnetimpl = impl,
-      dotnetos = os,
-      dotnetarch = arch,
-      tags = ["manual"],
-      visibility = ["//visibility:public"],
-      **kwargs
-  )
-  native.toolchain(
-      name = name,
-      toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain_net",
-      exec_compatible_with = host_constraints,
-      toolchain = ":"+impl_name,
-  )
+    impl_name = name + "-impl"
+    _net_toolchain(
+        name = impl_name,
+        dotnetimpl = impl,
+        dotnetos = os,
+        dotnetarch = arch,
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
+    native.toolchain(
+        name = name,
+        toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain_net",
+        exec_compatible_with = host_constraints,
+        toolchain = ":" + impl_name,
+    )

--- a/dotnet/private/providers.bzl
+++ b/dotnet/private/providers.bzl
@@ -1,4 +1,3 @@
-
 DotnetLibrary = provider()
 """
 A represenatation of the dotnet binary.

--- a/dotnet/private/repositories.bzl
+++ b/dotnet/private/repositories.bzl
@@ -1,33 +1,32 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-
 def dotnet_repositories():
-  http_file(
-      name = "nuget",
-      urls = ["https://dist.nuget.org/win-x86-commandline/v4.6.2/nuget.exe"],
-      sha256 = "2c562c1a18d720d4885546083ec8eaad6773a6b80befb02564088cc1e55b304e",
-  )
-    
-  http_archive(
-    name = "nunit2",
-    url = "https://github.com/nunit/nunitv2/archive/2.6.4.zip",
-    sha256 = "2db7b4356e7cd9ac022c3f211853e39ae7b3587915124b555c7c39f712902c28",
-    strip_prefix = "nunitv2-2.6.4",
-    build_file = "@io_bazel_rules_dotnet//dotnet/externals:BUILD.nunit2",
-  )
+    http_file(
+        name = "nuget",
+        urls = ["https://dist.nuget.org/win-x86-commandline/v4.6.2/nuget.exe"],
+        sha256 = "2c562c1a18d720d4885546083ec8eaad6773a6b80befb02564088cc1e55b304e",
+    )
 
-  http_archive(
-    name = "nunit3",
-    url = "https://www.nuget.org/api/v2/package/NUnit/3.10.1",
-    sha256 = "3529193f6028d7f7ccc65c6cb83d62d1b1c39a7d7ba5f74036cd6b69f55b10b6",
-    build_file = "@io_bazel_rules_dotnet//dotnet/externals:BUILD.nunit3",
-    type = "zip",
-  )
+    http_archive(
+        name = "nunit2",
+        url = "https://github.com/nunit/nunitv2/archive/2.6.4.zip",
+        sha256 = "2db7b4356e7cd9ac022c3f211853e39ae7b3587915124b555c7c39f712902c28",
+        strip_prefix = "nunitv2-2.6.4",
+        build_file = "@io_bazel_rules_dotnet//dotnet/externals:BUILD.nunit2",
+    )
 
-  http_archive(
-    name = "nunit3_consolerunner",
-    url = "https://www.nuget.org/api/v2/package/NUnit.ConsoleRunner/3.8.0",
-    sha256 = "785d80095c50f142727e741578297b2ef5e1a0e537e2511697ac25e8bd9fa2ae", 
-    build_file = "@io_bazel_rules_dotnet//dotnet/externals:BUILD.nunit3-consolerunner",
-    type = "zip",
-  )
+    http_archive(
+        name = "nunit3",
+        url = "https://www.nuget.org/api/v2/package/NUnit/3.10.1",
+        sha256 = "3529193f6028d7f7ccc65c6cb83d62d1b1c39a7d7ba5f74036cd6b69f55b10b6",
+        build_file = "@io_bazel_rules_dotnet//dotnet/externals:BUILD.nunit3",
+        type = "zip",
+    )
+
+    http_archive(
+        name = "nunit3_consolerunner",
+        url = "https://www.nuget.org/api/v2/package/NUnit.ConsoleRunner/3.8.0",
+        sha256 = "785d80095c50f142727e741578297b2ef5e1a0e537e2511697ac25e8bd9fa2ae",
+        build_file = "@io_bazel_rules_dotnet//dotnet/externals:BUILD.nunit3-consolerunner",
+        type = "zip",
+    )

--- a/dotnet/private/rules/binary.bzl
+++ b/dotnet/private/rules/binary.bzl
@@ -2,7 +2,6 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
@@ -105,60 +104,59 @@ $PREPARE $RUNFILES_MANIFEST_FILE
 $DIR/$EXEBASENAME "$@"
 """
 
-
 def _binary_impl(ctx):
-  """dotnet_binary_impl emits actions for compiling dotnet executable assembly."""
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
- 
-  if dotnet.assembly == None:
-    empty = dotnet.declare_file(dotnet, path="empty.sh")
-    dotnet.actions.write(output = empty, content = "echo assembly generations is not supported on this platform'")
-    library = dotnet.new_library(dotnet = dotnet)
-    return [library, DefaultInfo(executable = empty)]
+    """dotnet_binary_impl emits actions for compiling dotnet executable assembly."""
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  executable = dotnet.assembly(dotnet,
-      name = name,
-      srcs = ctx.attr.srcs,
-      deps = ctx.attr.deps,
-      resources = ctx.attr.resources,
-      out = ctx.attr.out,
-      defines = ctx.attr.defines,
-      unsafe = ctx.attr.unsafe,
-      data = ctx.attr.data,
-      executable = True,
-      keyfile = ctx.attr.keyfile,
-  )
+    if dotnet.assembly == None:
+        empty = dotnet.declare_file(dotnet, path = "empty.sh")
+        dotnet.actions.write(output = empty, content = "echo assembly generations is not supported on this platform'")
+        library = dotnet.new_library(dotnet = dotnet)
+        return [library, DefaultInfo(executable = empty)]
 
+    executable = dotnet.assembly(
+        dotnet,
+        name = name,
+        srcs = ctx.attr.srcs,
+        deps = ctx.attr.deps,
+        resources = ctx.attr.resources,
+        out = ctx.attr.out,
+        defines = ctx.attr.defines,
+        unsafe = ctx.attr.unsafe,
+        data = ctx.attr.data,
+        executable = True,
+        keyfile = ctx.attr.keyfile,
+    )
 
-  launcher = ctx.actions.declare_file("{}.bash".format(name))
-  content = ctx.attr._template.format(
-      prepare=ctx.attr._manifest_prep.files.to_list()[0].basename, 
-      launch=launcher.path, 
-      exebasename=executable.result.basename
-  )
-  ctx.actions.write(output = launcher, content = content, is_executable=True)  
-  if dotnet.runner != None:
-    runner = [dotnet.runner]
-  else:
-    runner = []
-  runfiles = ctx.runfiles(files = [launcher]  + ctx.attr._manifest_prep.files.to_list() + runner + ctx.attr._native_deps.files.to_list(), transitive_files=executable.runfiles)
+    launcher = ctx.actions.declare_file("{}.bash".format(name))
+    content = ctx.attr._template.format(
+        prepare = ctx.attr._manifest_prep.files.to_list()[0].basename,
+        launch = launcher.path,
+        exebasename = executable.result.basename,
+    )
+    ctx.actions.write(output = launcher, content = content, is_executable = True)
+    if dotnet.runner != None:
+        runner = [dotnet.runner]
+    else:
+        runner = []
+    runfiles = ctx.runfiles(files = [launcher] + ctx.attr._manifest_prep.files.to_list() + runner + ctx.attr._native_deps.files.to_list(), transitive_files = executable.runfiles)
 
-  return [
-      executable,
-      DefaultInfo(
-          files = depset([executable.result, launcher]),
-          runfiles = runfiles,
-          executable = launcher,
-      ),
-  ]
-  
+    return [
+        executable,
+        DefaultInfo(
+            files = depset([executable.result, launcher]),
+            runfiles = runfiles,
+            executable = launcher,
+        ),
+    ]
+
 dotnet_binary = rule(
     _binary_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -176,13 +174,13 @@ dotnet_binary = rule(
 core_binary = rule(
     _binary_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
-        "data": attr.label_list(allow_files = True),        
+        "data": attr.label_list(allow_files = True),
         "keyfile": attr.label(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
         "_native_deps": attr.label(default = Label("@core_sdk//:native_deps")),
@@ -196,9 +194,9 @@ core_binary = rule(
 net_binary = rule(
     _binary_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),

--- a/dotnet/private/rules/com_ref.bzl
+++ b/dotnet/private/rules/com_ref.bzl
@@ -2,64 +2,64 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
-    "sets"
+    "sets",
 )
 
 def _net_com_library_impl(ctx):
-  """_net_com_reference_impl emits actions for creating com wrapper library."""
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
- 
-   # Handle case of empty toolchain on linux and darwin
-  if dotnet.assembly == None:
-    library = dotnet.new_library(dotnet = dotnet)
-    return [library]
+    """_net_com_reference_impl emits actions for creating com wrapper library."""
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  com_library = dotnet.com_ref(dotnet,
-      name = name,
-      guid = ctx.attr.guid,
-      major_version = ctx.attr.major_version,
-      minor_version = ctx.attr.minor_version,
-      lcid = ctx.attr.lcid,
-      platform = ctx.attr.platform,
-      namespace = ctx.attr.namespace,
-      out = ctx.attr.out,
-  )
- 
-  deps = ctx.attr.deps
+    # Handle case of empty toolchain on linux and darwin
+    if dotnet.assembly == None:
+        library = dotnet.new_library(dotnet = dotnet)
+        return [library]
 
-  deps_libraries = [d[DotnetLibrary] for d in deps]
-  transitive = sets.union(deps_libraries, *[a[DotnetLibrary].transitive for a in deps])
+    com_library = dotnet.com_ref(
+        dotnet,
+        name = name,
+        guid = ctx.attr.guid,
+        major_version = ctx.attr.major_version,
+        minor_version = ctx.attr.minor_version,
+        lcid = ctx.attr.lcid,
+        platform = ctx.attr.platform,
+        namespace = ctx.attr.namespace,
+        out = ctx.attr.out,
+    )
 
-  library = dotnet.new_library(
-    dotnet = dotnet, 
-    name = name, 
-    deps = deps, 
-    transitive = transitive,
-    result = com_library)
+    deps = ctx.attr.deps
 
-  transitive_files = [d.result for d in library.transitive.to_list()]
+    deps_libraries = [d[DotnetLibrary] for d in deps]
+    transitive = sets.union(deps_libraries, *[a[DotnetLibrary].transitive for a in deps])
 
-  return [
-      library,
-      DefaultInfo(
-          files = depset([library.result]),
-          runfiles = ctx.runfiles(files = [dotnet.stdlib, library.result], transitive_files=depset(direct=transitive_files)),
-      ),
-  ]
-  
+    library = dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        result = com_library,
+    )
+
+    transitive_files = [d.result for d in library.transitive.to_list()]
+
+    return [
+        library,
+        DefaultInfo(
+            files = depset([library.result]),
+            runfiles = ctx.runfiles(files = [dotnet.stdlib, library.result], transitive_files = depset(direct = transitive_files)),
+        ),
+    ]
+
 net_com_library = rule(
     _net_com_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
+        "deps": attr.label_list(providers = [DotnetLibrary]),
         "guid": attr.string(),
         "major_version": attr.int(),
         "minor_version": attr.int(),
@@ -67,7 +67,7 @@ net_com_library = rule(
         "platform": attr.string(),
         "namespace": attr.string(),
         "out": attr.string(),
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data"))
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,

--- a/dotnet/private/rules/gac_net.bzl
+++ b/dotnet/private/rules/gac_net.bzl
@@ -7,16 +7,16 @@ _gac2_path = "C:/Windows/assembly"
 _gac4_path = "C:/Windows/Microsoft.NET/assembly"
 
 def _net_gac_impl(ctx, gac, prefix = None):
-  name = ctx.attr.name
-  version_token = "%s%s__%s" % (prefix if prefix != None else "", ctx.attr.version, ctx.attr.token)
+    name = ctx.attr.name
+    version_token = "%s%s__%s" % (prefix if prefix != None else "", ctx.attr.version, ctx.attr.token)
 
-  # csc.exe /reference:path 260 limit
-  for arch in ["GAC", "GAC_MSIL", "GAC_32", "GAC_64"]:
-    gac_path = ctx.path(paths.join(_gac2_path if gac == "gac2" else _gac4_path, arch, name, version_token))
-    if gac_path.exists:
-      ctx.symlink(gac_path, arch)
+    # csc.exe /reference:path 260 limit
+    for arch in ["GAC", "GAC_MSIL", "GAC_32", "GAC_64"]:
+        gac_path = ctx.path(paths.join(_gac2_path if gac == "gac2" else _gac4_path, arch, name, version_token))
+        if gac_path.exists:
+            ctx.symlink(gac_path, arch)
 
-  build_file_content = r'''package(default_visibility = [ "//visibility:public" ])
+    build_file_content = r'''package(default_visibility = [ "//visibility:public" ])
 load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "net_import_library")
 
 [net_import_library(
@@ -24,11 +24,11 @@ load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "net_import_library")
     src =  gac_assembly_arch + "/%s.dll"
 ) for gac_assembly_arch in ["GAC", "GAC_MSIL", "GAC_32", "GAC_64"]]    
   ''' % name
-  ctx.file("BUILD", build_file_content)
+    ctx.file("BUILD", build_file_content)
 
 _gac_attrs = {
-  "version":attr.string(mandatory=True),
-  "token":attr.string(mandatory=True)
+    "version": attr.string(mandatory = True),
+    "token": attr.string(mandatory = True),
 }
 
 def _net_gac2_impl(ctx):
@@ -36,7 +36,7 @@ def _net_gac2_impl(ctx):
 
 def _net_gac4_impl(ctx):
     _net_gac_impl(ctx, "gac4", "v4.0_")
-  
+
 net_gac2 = repository_rule(
     _net_gac2_impl,
     attrs = _gac_attrs,

--- a/dotnet/private/rules/import.bzl
+++ b/dotnet/private/rules/import.bzl
@@ -2,58 +2,58 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
 
 def _import_library_impl(ctx):
-  """net_import_library_impl emits actions for importing an external dll (for example provided by nuget)."""
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
- 
-  # Handle case of empty toolchain on linux and darwin
-  if dotnet.assembly == None:
-    library = dotnet.new_library(dotnet = dotnet)
-    return [library]
+    """net_import_library_impl emits actions for importing an external dll (for example provided by nuget)."""
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  deps = ctx.attr.deps
-  src = ctx.attr.src
-  result = src.files.to_list()[0]
+    # Handle case of empty toolchain on linux and darwin
+    if dotnet.assembly == None:
+        library = dotnet.new_library(dotnet = dotnet)
+        return [library]
 
-  if ctx.attr.data != None:
-    data = depset(direct=[], transitive = [t.files for t in ctx.attr.data])
-  else:
-    data = depset()
+    deps = ctx.attr.deps
+    src = ctx.attr.src
+    result = src.files.to_list()[0]
 
-  runfiles = depset(direct=[result] + [dotnet.stdlib], transitive=[d[DotnetLibrary].runfiles for d in deps]+[data])
-  transitive = depset(direct=deps, transitive=[a[DotnetLibrary].transitive for a in deps])
+    if ctx.attr.data != None:
+        data = depset(direct = [], transitive = [t.files for t in ctx.attr.data])
+    else:
+        data = depset()
 
-  library = dotnet.new_library(
-    dotnet = dotnet, 
-    name = name, 
-    deps = deps, 
-    transitive = transitive,
-    runfiles = runfiles,
-    result = result)
+    runfiles = depset(direct = [result] + [dotnet.stdlib], transitive = [d[DotnetLibrary].runfiles for d in deps] + [data])
+    transitive = depset(direct = deps, transitive = [a[DotnetLibrary].transitive for a in deps])
 
-  return [
-      library,
-      DefaultInfo(
-          files = depset([library.result]),
-          runfiles = ctx.runfiles(files = ctx.attr._native_deps.files.to_list(), transitive_files=library.runfiles),
-      ),
-  ]
-  
+    library = dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        runfiles = runfiles,
+        result = result,
+    )
+
+    return [
+        library,
+        DefaultInfo(
+            files = depset([library.result]),
+            runfiles = ctx.runfiles(files = ctx.attr._native_deps.files.to_list(), transitive_files = library.runfiles),
+        ),
+    ]
+
 dotnet_import_library = rule(
     _import_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory=True),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory = True),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
-        "_native_deps": attr.label(default = Label("@dotnet_sdk//:native_deps"))
+        "_native_deps": attr.label(default = Label("@dotnet_sdk//:native_deps")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain"],
     executable = False,
@@ -62,11 +62,11 @@ dotnet_import_library = rule(
 dotnet_import_binary = rule(
     _import_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory=True),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory = True),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
-        "_native_deps": attr.label(default = Label("@dotnet_sdk//:native_deps"))
+        "_native_deps": attr.label(default = Label("@dotnet_sdk//:native_deps")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain"],
     executable = False,
@@ -75,11 +75,11 @@ dotnet_import_binary = rule(
 core_import_library = rule(
     _import_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory=True),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory = True),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
-        "_native_deps": attr.label(default = Label("@core_sdk//:native_deps"))
+        "_native_deps": attr.label(default = Label("@core_sdk//:native_deps")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
     executable = False,
@@ -88,11 +88,11 @@ core_import_library = rule(
 core_import_binary = rule(
     _import_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory=True),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory = True),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
-        "_native_deps": attr.label(default = Label("@core_sdk//:native_deps"))
+        "_native_deps": attr.label(default = Label("@core_sdk//:native_deps")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
     executable = False,
@@ -101,11 +101,11 @@ core_import_binary = rule(
 net_import_library = rule(
     _import_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory=True),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory = True),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
-        "_native_deps": attr.label(default = Label("@net_sdk//:native_deps"))
+        "_native_deps": attr.label(default = Label("@net_sdk//:native_deps")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,
@@ -114,11 +114,11 @@ net_import_library = rule(
 net_import_binary = rule(
     _import_library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory=True),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "src": attr.label(allow_files = FileType([".dll", ".exe"]), mandatory = True),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
-        "_native_deps": attr.label(default = Label("@net_sdk//:native_deps"))
+        "_native_deps": attr.label(default = Label("@net_sdk//:native_deps")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,

--- a/dotnet/private/rules/library.bzl
+++ b/dotnet/private/rules/library.bzl
@@ -2,59 +2,58 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
     "DotnetResource",
 )
 
-
 def _library_impl(ctx):
-  """_library_impl emits actions for compiling dotnet executable assembly."""
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
-  
-  # Handle case of empty toolchain on linux and darwin
-  if dotnet.assembly == None:
-    library = dotnet.new_library(dotnet = dotnet)
-    return [library]
+    """_library_impl emits actions for compiling dotnet executable assembly."""
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  library = dotnet.assembly(dotnet,
-      name = name,
-      srcs = ctx.attr.srcs,
-      deps = ctx.attr.deps,
-      resources = ctx.attr.resources,
-      out = ctx.attr.out,
-      defines = ctx.attr.defines,
-      unsafe = ctx.attr.unsafe,
-      data = ctx.attr.data,
-      keyfile = ctx.attr.keyfile,
-      executable = False,
-  )
+    # Handle case of empty toolchain on linux and darwin
+    if dotnet.assembly == None:
+        library = dotnet.new_library(dotnet = dotnet)
+        return [library]
 
-  runfiles = ctx.runfiles(files = [], transitive_files=library.runfiles)
+    library = dotnet.assembly(
+        dotnet,
+        name = name,
+        srcs = ctx.attr.srcs,
+        deps = ctx.attr.deps,
+        resources = ctx.attr.resources,
+        out = ctx.attr.out,
+        defines = ctx.attr.defines,
+        unsafe = ctx.attr.unsafe,
+        data = ctx.attr.data,
+        keyfile = ctx.attr.keyfile,
+        executable = False,
+    )
 
-  return [
-      library,
-      DefaultInfo(
-          files = depset([library.result]),
-          runfiles = runfiles,
-      ),
-  ]
-  
+    runfiles = ctx.runfiles(files = [], transitive_files = library.runfiles)
+
+    return [
+        library,
+        DefaultInfo(
+            files = depset([library.result]),
+            runfiles = runfiles,
+        ),
+    ]
+
 dotnet_library = rule(
     _library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
         "data": attr.label_list(),
         "keyfile": attr.label(allow_files = True),
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data"))
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain"],
     executable = False,
@@ -63,15 +62,15 @@ dotnet_library = rule(
 core_library = rule(
     _library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
-        "data": attr.label_list(allow_files = True),        
+        "data": attr.label_list(allow_files = True),
         "keyfile": attr.label(allow_files = True),
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data"))
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
     executable = False,
@@ -80,15 +79,15 @@ core_library = rule(
 net_library = rule(
     _library_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
-        "data": attr.label_list(allow_files = True),        
+        "data": attr.label_list(allow_files = True),
         "keyfile": attr.label(allow_files = True),
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data"))
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,

--- a/dotnet/private/rules/nuget.bzl
+++ b/dotnet/private/rules/nuget.bzl
@@ -2,60 +2,68 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
-    "paths", "dicts"
+    "dicts",
+    "paths",
 )
 
-
-def _dotnet_nuget_impl(ctx,                         
+def _dotnet_nuget_impl(
+        ctx,
         build_file = None,
         build_file_content = None):
-  """dotnet_nuget_impl emits actions for exposing nunit assmebly."""
+    """dotnet_nuget_impl emits actions for exposing nunit assmebly."""
 
-  package = ctx.attr.package
-  output_dir = ctx.path("")
-  if ctx.attr.use_nuget_client and ctx.os.name.startswith('windows'):
-    """use_nuget_client for private nuget feed (tfs/vsts/etc)"""
-    nuget = ctx.path(ctx.attr._nuget_exe)
-    nuget_cmd = [nuget, "install", "-Version", ctx.attr.version,
-                    "-OutputDirectory", output_dir,
-                    "-Source", ctx.attr.source, ctx.attr.package]
-    result = ctx.execute(nuget_cmd)
-    if result.return_code:
-        fail("Nuget command failed: %s (%s)" % (result.stderr, " ".join(nuget_cmd)))
-  else:
-    url = ctx.attr.source + "/" + ctx.attr.package + "/" + ctx.attr.version
-    ctx.download_and_extract(url, output_dir, ctx.attr.sha256, type="zip")  
+    package = ctx.attr.package
+    output_dir = ctx.path("")
+    if ctx.attr.use_nuget_client and ctx.os.name.startswith("windows"):
+        """use_nuget_client for private nuget feed (tfs/vsts/etc)"""
+        nuget = ctx.path(ctx.attr._nuget_exe)
+        nuget_cmd = [
+            nuget,
+            "install",
+            "-Version",
+            ctx.attr.version,
+            "-OutputDirectory",
+            output_dir,
+            "-Source",
+            ctx.attr.source,
+            ctx.attr.package,
+        ]
+        result = ctx.execute(nuget_cmd)
+        if result.return_code:
+            fail("Nuget command failed: %s (%s)" % (result.stderr, " ".join(nuget_cmd)))
+    else:
+        url = ctx.attr.source + "/" + ctx.attr.package + "/" + ctx.attr.version
+        ctx.download_and_extract(url, output_dir, ctx.attr.sha256, type = "zip")
 
-  build_file_name = "BUILD" if not ctx.path("BUILD").exists else "BUILD.bazel"
+    build_file_name = "BUILD" if not ctx.path("BUILD").exists else "BUILD.bazel"
 
-  if build_file_content:
-    ctx.file(build_file_name, build_file_content)
-  elif build_file:
-    ctx.symlink(ctx.path(build_file), build_file_name)
-  else:
-    ctx.template(build_file_name,
-        Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.nuget.bazel"),
-        executable = False,
-    )
+    if build_file_content:
+        ctx.file(build_file_name, build_file_content)
+    elif build_file:
+        ctx.symlink(ctx.path(build_file), build_file_name)
+    else:
+        ctx.template(
+            build_file_name,
+            Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.nuget.bazel"),
+            executable = False,
+        )
 
 _dotnet_nuget_attrs = {
-    "_nuget_exe": attr.label(default=Label("@nuget//file:nuget.exe")),
+    "_nuget_exe": attr.label(default = Label("@nuget//file:nuget.exe")),
     # Sources to download the nuget packages from
     "source": attr.string(default = "https://www.nuget.org/api/v2/package"),
     # The name of the nuget package
-    "package": attr.string(mandatory=True),
+    "package": attr.string(mandatory = True),
     # The version of the nuget package
-    "version": attr.string(mandatory=True),
-    "sha256": attr.string(mandatory=False),
-    "use_nuget_client": attr.bool(default=False)
+    "version": attr.string(mandatory = True),
+    "sha256": attr.string(mandatory = False),
+    "use_nuget_client": attr.bool(default = False),
 }
 
 dotnet_nuget = repository_rule(
@@ -64,11 +72,11 @@ dotnet_nuget = repository_rule(
 )
 
 def _dotnet_nuget_new_impl(repository_ctx):
-  build_file = repository_ctx.attr.build_file
-  build_file_content = repository_ctx.attr.build_file_content
-  if not (build_file_content or build_file):
-    fail("build_file or build_file_content is required")
-  _dotnet_nuget_impl(repository_ctx, build_file, build_file_content)
+    build_file = repository_ctx.attr.build_file
+    build_file_content = repository_ctx.attr.build_file_content
+    if not (build_file_content or build_file):
+        fail("build_file or build_file_content is required")
+    _dotnet_nuget_impl(repository_ctx, build_file, build_file_content)
 
 dotnet_nuget_new = repository_rule(
     _dotnet_nuget_new_impl,
@@ -91,7 +99,6 @@ _FUNC = """
 )
 
 """
-
 
 def _get_importlib(func, name, lib, deps, files):
     depsstr = ""
@@ -130,30 +137,29 @@ def _nuget_package_impl(ctx):
     package = ctx.attr.package
     output_dir = ctx.path("")
     url = ctx.attr.source + "/" + ctx.attr.package + "/" + ctx.attr.version
-    ctx.download_and_extract(url, output_dir, ctx.attr.sha256, type="zip")  
+    ctx.download_and_extract(url, output_dir, ctx.attr.sha256, type = "zip")
 
     build_file_name = "BUILD" if not ctx.path("BUILD").exists else "BUILD.bazel"
 
     ctx.file(build_file_name, content)
 
-
 _nuget_package_attrs = {
     # Sources to download the nuget packages from
     "source": attr.string(default = "https://www.nuget.org/api/v2/package"),
     # The name of the nuget package
-    "package": attr.string(mandatory=True),
+    "package": attr.string(mandatory = True),
     # The version of the nuget package
-    "version": attr.string(mandatory=True),
-    "sha256": attr.string(mandatory=False),
-    "core_lib": attr.string(default=""),
-    "net_lib": attr.string(default=""),
-    "mono_lib": attr.string(default=""),
-    "core_tool": attr.string(default=""),
-    "net_tool": attr.string(default=""),
-    "mono_tool": attr.string(default=""),
-    "core_deps": attr.label_list(providers=[DotnetLibrary]),
-    "net_deps": attr.label_list(providers=[DotnetLibrary]),
-    "mono_deps": attr.label_list(providers=[DotnetLibrary]),
+    "version": attr.string(mandatory = True),
+    "sha256": attr.string(mandatory = False),
+    "core_lib": attr.string(default = ""),
+    "net_lib": attr.string(default = ""),
+    "mono_lib": attr.string(default = ""),
+    "core_tool": attr.string(default = ""),
+    "net_tool": attr.string(default = ""),
+    "mono_tool": attr.string(default = ""),
+    "core_deps": attr.label_list(providers = [DotnetLibrary]),
+    "net_deps": attr.label_list(providers = [DotnetLibrary]),
+    "mono_deps": attr.label_list(providers = [DotnetLibrary]),
     "core_files": attr.string_list(),
     "net_files": attr.string_list(),
     "mono_files": attr.string_list(),

--- a/dotnet/private/rules/resource_core.bzl
+++ b/dotnet/private/rules/resource_core.bzl
@@ -4,31 +4,31 @@ load(
 )
 
 def _core_resource_impl(ctx):
-  """core_resource_impl emits actions for embeding file as resource."""
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
- 
-  resource = dotnet.new_resource(
-     dotnet = dotnet, 
-     name = name, 
-     result = ctx.attr.src.files.to_list()[0],
-     identifier = ctx.attr.identifier)
+    """core_resource_impl emits actions for embeding file as resource."""
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  
-  return [
-      resource,
-      DefaultInfo(
-          files = depset([resource.result]),
-      ),
-  ]
-  
+    resource = dotnet.new_resource(
+        dotnet = dotnet,
+        name = name,
+        result = ctx.attr.src.files.to_list()[0],
+        identifier = ctx.attr.identifier,
+    )
+
+    return [
+        resource,
+        DefaultInfo(
+            files = depset([resource.result]),
+        ),
+    ]
+
 core_resource = rule(
     _core_resource_impl,
     attrs = {
         # source files for this target.
-        "src": attr.label(allow_files = True, mandatory=True),        
+        "src": attr.label(allow_files = True, mandatory = True),
         "identifier": attr.string(),
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data"))
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
     executable = False,

--- a/dotnet/private/rules/resx.bzl
+++ b/dotnet/private/rules/resx.bzl
@@ -3,38 +3,38 @@ load(
     "dotnet_context",
 )
 
-
 def _resx_impl(ctx):
-  """dotnet_resx_impl emits actions for compiling resx to resource."""
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
- 
-  # Handle case of empty toolchain on linux and darwin
-  if dotnet.resx == None:
-    result = dotnet.declare_file(dotnet, path="empty.resources")
-    dotnet.actions.write(output = result, content = ".net not supported on this platform")
-    empty = dotnet.new_resource(dotnet = dotnet, name = name, result=result)
-    return [empty]
+    """dotnet_resx_impl emits actions for compiling resx to resource."""
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  resource = dotnet.resx(dotnet,
-      name = name,
-      src = ctx.attr.src,
-      identifier = ctx.attr.identifier,
-      out = ctx.attr.out,
-      customresgen = ctx.attr._simpleresgen,
-  )
-  return [
-      resource,
-      DefaultInfo(
-          files = depset([resource.result]),
-      ),
-  ]
-  
+    # Handle case of empty toolchain on linux and darwin
+    if dotnet.resx == None:
+        result = dotnet.declare_file(dotnet, path = "empty.resources")
+        dotnet.actions.write(output = result, content = ".net not supported on this platform")
+        empty = dotnet.new_resource(dotnet = dotnet, name = name, result = result)
+        return [empty]
+
+    resource = dotnet.resx(
+        dotnet,
+        name = name,
+        src = ctx.attr.src,
+        identifier = ctx.attr.identifier,
+        out = ctx.attr.out,
+        customresgen = ctx.attr._simpleresgen,
+    )
+    return [
+        resource,
+        DefaultInfo(
+            files = depset([resource.result]),
+        ),
+    ]
+
 net_resx = rule(
     _resx_impl,
     attrs = {
         # source files for this target.
-        "src": attr.label(allow_files = FileType([".resx"]), mandatory=True),        
+        "src": attr.label(allow_files = FileType([".resx"]), mandatory = True),
         "identifier": attr.string(),
         "out": attr.string(),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
@@ -42,12 +42,12 @@ net_resx = rule(
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,
-)  
+)
 dotnet_resx = rule(
     _resx_impl,
     attrs = {
         # source files for this target.
-        "src": attr.label(allow_files = FileType([".resx"]), mandatory=True),        
+        "src": attr.label(allow_files = FileType([".resx"]), mandatory = True),
         "identifier": attr.string(),
         "out": attr.string(),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
@@ -61,7 +61,7 @@ core_resx = rule(
     _resx_impl,
     attrs = {
         # source files for this target.
-        "src": attr.label(allow_files = FileType([".resx"]), mandatory=True),        
+        "src": attr.label(allow_files = FileType([".resx"]), mandatory = True),
         "identifier": attr.string(),
         "out": attr.string(),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
@@ -69,4 +69,4 @@ core_resx = rule(
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
     executable = False,
-)  
+)

--- a/dotnet/private/rules/stdlib.bzl
+++ b/dotnet/private/rules/stdlib.bzl
@@ -2,52 +2,51 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
 )
 
 def _stdlib_impl(ctx):
-  dotnet = dotnet_context(ctx) 
-  name = ctx.label.name
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  if dotnet.stdlib_byname == None:
-    library = dotnet.new_library(dotnet = dotnet)
-    return [library]
+    if dotnet.stdlib_byname == None:
+        library = dotnet.new_library(dotnet = dotnet)
+        return [library]
 
-  result = dotnet.stdlib_byname(name = name, shared = dotnet.shared, lib = dotnet.lib, libVersion = dotnet.libVersion)
+    result = dotnet.stdlib_byname(name = name, shared = dotnet.shared, lib = dotnet.lib, libVersion = dotnet.libVersion)
 
-  deps = ctx.attr.deps
-  transitive = depset(direct = deps, transitive = [a[DotnetLibrary].transitive for a in deps])
-  extra = depset(direct = [result], transitive = [t.files for t in ctx.attr.data])
-  direct = extra.to_list()
-    
-  runfiles = depset(direct = direct, transitive = [a[DotnetLibrary].runfiles for a in deps])
+    deps = ctx.attr.deps
+    transitive = depset(direct = deps, transitive = [a[DotnetLibrary].transitive for a in deps])
+    extra = depset(direct = [result], transitive = [t.files for t in ctx.attr.data])
+    direct = extra.to_list()
 
-  library = dotnet.new_library(
-    dotnet = dotnet, 
-    name = name, 
-    deps = deps, 
-    transitive = transitive,
-    runfiles = runfiles,
-    result = result)
+    runfiles = depset(direct = direct, transitive = [a[DotnetLibrary].runfiles for a in deps])
 
-  return [
-      library,
-      DefaultInfo(
-          files = depset([library.result]),
-          runfiles = ctx.runfiles(files = [], transitive_files = runfiles),
-      ),
-  ]
+    library = dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        runfiles = runfiles,
+        result = result,
+    )
 
-  
+    return [
+        library,
+        DefaultInfo(
+            files = depset([library.result]),
+            runfiles = ctx.runfiles(files = [], transitive_files = runfiles),
+        ),
+    ]
+
 dotnet_stdlib = rule(
     _stdlib_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),        
-        "data": attr.label_list(allow_files = True),        
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data"))
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "data": attr.label_list(allow_files = True),
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain"],
     executable = False,
@@ -56,8 +55,8 @@ dotnet_stdlib = rule(
 core_stdlib = rule(
     _stdlib_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),        
-        "data": attr.label_list(allow_files = True),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "data": attr.label_list(allow_files = True),
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
@@ -67,11 +66,10 @@ core_stdlib = rule(
 net_stdlib = rule(
     _stdlib_impl,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),        
-        "data": attr.label_list(allow_files = True),        
-        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data"))
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "data": attr.label_list(allow_files = True),
+        "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,
 )
-

--- a/dotnet/private/rules/test.bzl
+++ b/dotnet/private/rules/test.bzl
@@ -2,7 +2,6 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:context.bzl",
     "dotnet_context",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
     "DotnetLibrary",
@@ -234,66 +233,67 @@ exit $result
 """
 
 def _unit_test(ctx):
-  dotnet = dotnet_context(ctx)
-  name = ctx.label.name
- 
-  # Handle case of empty toolchain on linux and darwin
-  if dotnet.assembly == None:
-    empty = dotnet.declare_file(dotnet, path="empty.sh")
-    dotnet.actions.write(output = empty, content = "echo '.net not supported on this platform'")
-    library = dotnet.new_library(dotnet = dotnet)
-    return [library, DefaultInfo(executable = empty)]
+    dotnet = dotnet_context(ctx)
+    name = ctx.label.name
 
-  library = dotnet.assembly(dotnet,
-      name = name,
-      srcs = ctx.attr.srcs,
-      deps = ctx.attr.deps,
-      resources = ctx.attr.resources,
-      out = ctx.attr.out,
-      defines = ctx.attr.defines,
-      unsafe = ctx.attr.unsafe,
-      data = ctx.attr.data,
-      executable = False,
-  )
+    # Handle case of empty toolchain on linux and darwin
+    if dotnet.assembly == None:
+        empty = dotnet.declare_file(dotnet, path = "empty.sh")
+        dotnet.actions.write(output = empty, content = "echo '.net not supported on this platform'")
+        library = dotnet.new_library(dotnet = dotnet)
+        return [library, DefaultInfo(executable = empty)]
 
-  testlauncher = ctx.attr.testlauncher.files.to_list()[0].basename
+    library = dotnet.assembly(
+        dotnet,
+        name = name,
+        srcs = ctx.attr.srcs,
+        deps = ctx.attr.deps,
+        resources = ctx.attr.resources,
+        out = ctx.attr.out,
+        defines = ctx.attr.defines,
+        unsafe = ctx.attr.unsafe,
+        data = ctx.attr.data,
+        executable = False,
+    )
 
-  launcher = ctx.actions.declare_file("{}.bash".format(name))
-  content = ctx.attr._template.format(
-      prepare=ctx.attr._manifest_prep.files.to_list()[0].basename, 
-      launch=launcher.path, 
-      exebasename=library.result.basename,
-      testlauncher = testlauncher,
-      xslt = ctx.attr._xslt.files.to_list()[0].basename, 
-  )
-  ctx.actions.write(output = launcher, content = content, is_executable=True)
+    testlauncher = ctx.attr.testlauncher.files.to_list()[0].basename
 
-  files = []
-  if launcher != None:
-    files += [launcher]
-  if dotnet.runner != None:
-    files += [dotnet.runner]
-  files += ctx.attr._manifest_prep.files.to_list() + ctx.attr._native_deps.files.to_list() + ctx.attr._xslt.files.to_list()
+    launcher = ctx.actions.declare_file("{}.bash".format(name))
+    content = ctx.attr._template.format(
+        prepare = ctx.attr._manifest_prep.files.to_list()[0].basename,
+        launch = launcher.path,
+        exebasename = library.result.basename,
+        testlauncher = testlauncher,
+        xslt = ctx.attr._xslt.files.to_list()[0].basename,
+    )
+    ctx.actions.write(output = launcher, content = content, is_executable = True)
 
-  runfiles = ctx.runfiles(files = files, transitive_files=library.runfiles)
-  test_launcher_runfiles = ctx.runfiles(files=[ctx.attr.testlauncher[DotnetLibrary].result], transitive_files = ctx.attr.testlauncher[DotnetLibrary].runfiles)
-  runfiles = runfiles.merge(test_launcher_runfiles)
+    files = []
+    if launcher != None:
+        files += [launcher]
+    if dotnet.runner != None:
+        files += [dotnet.runner]
+    files += ctx.attr._manifest_prep.files.to_list() + ctx.attr._native_deps.files.to_list() + ctx.attr._xslt.files.to_list()
 
-  return [
-      library,
-      DefaultInfo(
-          files = depset([library.result, launcher]),
-          runfiles = runfiles,
-          executable = launcher,
-      ),
-  ]
-  
+    runfiles = ctx.runfiles(files = files, transitive_files = library.runfiles)
+    test_launcher_runfiles = ctx.runfiles(files = [ctx.attr.testlauncher[DotnetLibrary].result], transitive_files = ctx.attr.testlauncher[DotnetLibrary].runfiles)
+    runfiles = runfiles.merge(test_launcher_runfiles)
+
+    return [
+        library,
+        DefaultInfo(
+            files = depset([library.result, launcher]),
+            runfiles = runfiles,
+            executable = launcher,
+        ),
+    ]
+
 dotnet_nunit_test = rule(
     _unit_test,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -301,9 +301,9 @@ dotnet_nunit_test = rule(
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
         "_manifest_prep": attr.label(default = Label("//dotnet/tools/manifest_prep")),
         "_native_deps": attr.label(default = Label("@dotnet_sdk//:native_deps")),
-        "testlauncher": attr.label(default = "@nunit2//:nunit-console-runner-exe", providers=[DotnetLibrary]),
+        "testlauncher": attr.label(default = "@nunit2//:nunit-console-runner-exe", providers = [DotnetLibrary]),
         "_template": attr.string(default = _TEMPLATE_NUNIT_MONO),
-        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files=True),
+        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files = True),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain"],
     executable = True,
@@ -313,9 +313,9 @@ dotnet_nunit_test = rule(
 net_nunit_test = rule(
     _unit_test,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -323,9 +323,9 @@ net_nunit_test = rule(
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
         "_manifest_prep": attr.label(default = Label("//dotnet/tools/manifest_prep")),
         "_native_deps": attr.label(default = Label("@net_sdk//:native_deps")),
-        "testlauncher": attr.label(default = "@nunit2//:net.nunit-console-runner-exe", providers=[DotnetLibrary]),
+        "testlauncher": attr.label(default = "@nunit2//:net.nunit-console-runner-exe", providers = [DotnetLibrary]),
         "_template": attr.string(default = _TEMPLATE_NUNIT_NET),
-        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files=True),
+        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files = True),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = True,
@@ -335,9 +335,9 @@ net_nunit_test = rule(
 net_nunit3_test = rule(
     _unit_test,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -345,9 +345,9 @@ net_nunit3_test = rule(
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
         "_manifest_prep": attr.label(default = Label("//dotnet/tools/manifest_prep")),
         "_native_deps": attr.label(default = Label("@net_sdk//:native_deps")),
-        "testlauncher": attr.label(default = "@nunit3_consolerunner//:nunit3.console.exe", providers=[DotnetLibrary]),
+        "testlauncher": attr.label(default = "@nunit3_consolerunner//:nunit3.console.exe", providers = [DotnetLibrary]),
         "_template": attr.string(default = _TEMPLATE_NUNIT3_NET),
-        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files=True),
+        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files = True),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = True,
@@ -357,9 +357,9 @@ net_nunit3_test = rule(
 core_xunit_test = rule(
     _unit_test,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -367,9 +367,9 @@ core_xunit_test = rule(
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:core_context_data")),
         "_manifest_prep": attr.label(default = Label("//dotnet/tools/manifest_prep")),
         "_native_deps": attr.label(default = Label("@core_sdk//:native_deps")),
-        "testlauncher": attr.label(default = "@xunit.runner.console//:core_tool", providers=[DotnetLibrary]),
+        "testlauncher": attr.label(default = "@xunit.runner.console//:core_tool", providers = [DotnetLibrary]),
         "_template": attr.string(default = _TEMPLATE_XUNIT_CORE),
-        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files=True),
+        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files = True),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_core"],
     executable = True,
@@ -379,9 +379,9 @@ core_xunit_test = rule(
 net_xunit_test = rule(
     _unit_test,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -389,9 +389,9 @@ net_xunit_test = rule(
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:net_context_data")),
         "_manifest_prep": attr.label(default = Label("//dotnet/tools/manifest_prep")),
         "_native_deps": attr.label(default = Label("@net_sdk//:native_deps")),
-        "testlauncher": attr.label(default = "@xunit.runner.console//:net_tool", providers=[DotnetLibrary]),
+        "testlauncher": attr.label(default = "@xunit.runner.console//:net_tool", providers = [DotnetLibrary]),
         "_template": attr.string(default = _TEMPLATE_XUNIT_NET),
-        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files=True),
+        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files = True),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = True,
@@ -401,9 +401,9 @@ net_xunit_test = rule(
 dotnet_xunit_test = rule(
     _unit_test,
     attrs = {
-        "deps": attr.label_list(providers=[DotnetLibrary]),
-        "resources": attr.label_list(providers=[DotnetResource]),
-        "srcs": attr.label_list(allow_files = FileType([".cs"])),        
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResource]),
+        "srcs": attr.label_list(allow_files = FileType([".cs"])),
         "out": attr.string(),
         "defines": attr.string_list(),
         "unsafe": attr.bool(default = False),
@@ -411,13 +411,11 @@ dotnet_xunit_test = rule(
         "_dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:dotnet_context_data")),
         "_manifest_prep": attr.label(default = Label("//dotnet/tools/manifest_prep")),
         "_native_deps": attr.label(default = Label("@dotnet_sdk//:native_deps")),
-        "testlauncher": attr.label(default = "@xunit.runner.console//:mono_tool", providers=[DotnetLibrary]),
+        "testlauncher": attr.label(default = "@xunit.runner.console//:mono_tool", providers = [DotnetLibrary]),
         "_template": attr.string(default = _TEMPLATE_XUNIT_MONO),
-        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files=True),
+        "_xslt": attr.label(default = Label("@io_bazel_rules_dotnet//tools/converttests:n3.xslt"), allow_files = True),
     },
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain"],
     executable = True,
     test = True,
 )
-
-  

--- a/dotnet/private/rules/vs_ref_net.bzl
+++ b/dotnet/private/rules/vs_ref_net.bzl
@@ -6,8 +6,11 @@ load(
 def _vs2017_ref_net_impl(ctx):
     prefix = "vs"
     for vs_type in ["Community", "Professional", "Enterprise"]:
-        vs_ref_path = paths.join("C:/Program Files (x86)/Microsoft Visual Studio/2017", 
-            vs_type, "Common7/IDE/ReferenceAssemblies")
+        vs_ref_path = paths.join(
+            "C:/Program Files (x86)/Microsoft Visual Studio/2017",
+            vs_type,
+            "Common7/IDE/ReferenceAssemblies",
+        )
         if ctx.path(vs_ref_path).exists:
             ctx.symlink(vs_ref_path, prefix)
 
@@ -22,5 +25,5 @@ load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "net_import_library")
     ctx.file("BUILD", build_file_content)
 
 vs2017_ref_net = repository_rule(
-    implementation=_vs2017_ref_net_impl,
+    implementation = _vs2017_ref_net_impl,
 )

--- a/dotnet/private/sdk.bzl
+++ b/dotnet/private/sdk.bzl
@@ -1,87 +1,87 @@
-load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "executable_extension", "bat_extension", "paths")
+load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "bat_extension", "executable_extension", "paths")
 
 # Mono for linux, windows and macos layouts fies differentely
 # So we provide an implementation for each host
 def _dotnet_host_sdk_impl_windows(ctx):
-  mono, mcs = _detect_host_sdk(ctx)
-  _sdk_build_file(ctx)
-  bin = ctx.path(mcs).dirname
-  ctx.symlink(bin, "mcs_bin")
-  bin = ctx.path(mono).dirname
-  ctx.symlink(bin, "mono_bin")
-  lib = paths.join("{}".format(ctx.path(mcs).dirname), "../lib")
-  ctx.symlink(lib, "lib")
-
+    mono, mcs = _detect_host_sdk(ctx)
+    _sdk_build_file(ctx)
+    bin = ctx.path(mcs).dirname
+    ctx.symlink(bin, "mcs_bin")
+    bin = ctx.path(mono).dirname
+    ctx.symlink(bin, "mono_bin")
+    lib = paths.join("{}".format(ctx.path(mcs).dirname), "../lib")
+    ctx.symlink(lib, "lib")
 
 # Mono launcher is on Linux usually placed in /usr/bin. Since the directory
 # may contain forbidden file names ('[') we cannot link it in dotnet_sdk
 # Instead we create a directory (named mono_bin) and put link to mono in it
 def _dotnet_host_sdk_impl_linux(ctx):
-  mono, mcs = _detect_host_sdk(ctx)
-  _sdk_build_file(ctx)
-  ctx.file("mono_bin/README.md",
-    "Directory to hold link to mono executable",
-    False
-  )
-  ctx.symlink(mono, "mono_bin/mono")
-  monoroot = ctx.path("/usr/lib/mono/")
-  if not monoroot.exists:
-    fail("Can't find mono in /usr/lib/mono/")
-  ctx.symlink(monoroot, "lib")
-  bin = paths.join("{}".format(monoroot), "4.5")
-  ctx.symlink(bin, "mcs_bin")
+    mono, mcs = _detect_host_sdk(ctx)
+    _sdk_build_file(ctx)
+    ctx.file(
+        "mono_bin/README.md",
+        "Directory to hold link to mono executable",
+        False,
+    )
+    ctx.symlink(mono, "mono_bin/mono")
+    monoroot = ctx.path("/usr/lib/mono/")
+    if not monoroot.exists:
+        fail("Can't find mono in /usr/lib/mono/")
+    ctx.symlink(monoroot, "lib")
+    bin = paths.join("{}".format(monoroot), "4.5")
+    ctx.symlink(bin, "mcs_bin")
 
 def _dotnet_host_sdk_impl_osx(ctx):
-  mono, mcs = _detect_host_sdk(ctx)
-  _sdk_build_file(ctx)
-  ctx.file("mono_bin/README.md",
-    "Directory to hold link to mono executable",
-    False
-  )
-  ctx.symlink(mono, "mono_bin/mono")
-  monoroot = ctx.path("/usr/local/Cellar/mono/5.4.1.6/lib/mono")
-  if not monoroot.exists:
-    current = ctx.path(mono).dirname
-    monodir = paths.join("{}".format(current), "..", "lib", "mono")
-    monoroot = ctx.path(monodir)
+    mono, mcs = _detect_host_sdk(ctx)
+    _sdk_build_file(ctx)
+    ctx.file(
+        "mono_bin/README.md",
+        "Directory to hold link to mono executable",
+        False,
+    )
+    ctx.symlink(mono, "mono_bin/mono")
+    monoroot = ctx.path("/usr/local/Cellar/mono/5.4.1.6/lib/mono")
     if not monoroot.exists:
-      fail("Can't find mono in /usr/local/Cellar/mono/5.4.1.6/lib/mono")
-  ctx.symlink(monoroot, "lib")
-  bin = paths.join("{}".format(monoroot), "4.5")
-  ctx.symlink(bin, "mcs_bin")
+        current = ctx.path(mono).dirname
+        monodir = paths.join("{}".format(current), "..", "lib", "mono")
+        monoroot = ctx.path(monodir)
+        if not monoroot.exists:
+            fail("Can't find mono in /usr/local/Cellar/mono/5.4.1.6/lib/mono")
+    ctx.symlink(monoroot, "lib")
+    bin = paths.join("{}".format(monoroot), "4.5")
+    ctx.symlink(bin, "mcs_bin")
 
 def _dotnet_host_sdk_impl(ctx):
-  if ctx.os.name == 'linux':
-    _dotnet_host_sdk_impl_linux(ctx)
-  elif ctx.os.name == 'mac os x':
-    _dotnet_host_sdk_impl_osx(ctx)
-  elif ctx.os.name.startswith('windows'):
-    _dotnet_host_sdk_impl_windows(ctx)
-  
+    if ctx.os.name == "linux":
+        _dotnet_host_sdk_impl_linux(ctx)
+    elif ctx.os.name == "mac os x":
+        _dotnet_host_sdk_impl_osx(ctx)
+    elif ctx.os.name.startswith("windows"):
+        _dotnet_host_sdk_impl_windows(ctx)
 
 dotnet_host_sdk = repository_rule(
-    implementation = _dotnet_host_sdk_impl, 
-    local=True,
+    implementation = _dotnet_host_sdk_impl,
+    local = True,
 )
 
 def _dotnet_download_sdk_impl(ctx):
-  if ctx.os.name == 'linux':
-    host = "mono_linux_amd64"
-  elif ctx.os.name == 'mac os x':
-    host = "mono_darwin_amd64"
-  elif ctx.os.name.startswith('windows'):
-    host = "mono_windows_amd64"
-  else:
-    fail("Unsupported operating system: " + ctx.os.name)
-  sdks = ctx.attr.sdks
-  if host not in sdks: fail("Unsupported host {}".format(host))
-  filename, sha256 = ctx.attr.sdks[host]
-  _sdk_build_file(ctx)
-  _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
-  ctx.symlink("mono/lib/mono/4.5", "mcs_bin")
-  ctx.symlink("mono/bin", "mono_bin")
-  ctx.symlink("mono/lib/mono", "lib")
-
+    if ctx.os.name == "linux":
+        host = "mono_linux_amd64"
+    elif ctx.os.name == "mac os x":
+        host = "mono_darwin_amd64"
+    elif ctx.os.name.startswith("windows"):
+        host = "mono_windows_amd64"
+    else:
+        fail("Unsupported operating system: " + ctx.os.name)
+    sdks = ctx.attr.sdks
+    if host not in sdks:
+        fail("Unsupported host {}".format(host))
+    filename, sha256 = ctx.attr.sdks[host]
+    _sdk_build_file(ctx)
+    _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
+    ctx.symlink("mono/lib/mono/4.5", "mcs_bin")
+    ctx.symlink("mono/bin", "mono_bin")
+    ctx.symlink("mono/lib/mono", "lib")
 
 dotnet_download_sdk = repository_rule(
     _dotnet_download_sdk_impl,
@@ -93,11 +93,11 @@ dotnet_download_sdk = repository_rule(
 )
 
 def _dotnet_local_sdk_impl(ctx):
-  _sdk_build_file(ctx)
-  bin = paths.join(ctx.attr.path, "/bin")
-  ctx.symlink(bin, "bin")
-  lib = paths.join(ctx.attr.path, "/lib")
-  ctx.symlink(lib, "lib")
+    _sdk_build_file(ctx)
+    bin = paths.join(ctx.attr.path, "/bin")
+    ctx.symlink(bin, "bin")
+    lib = paths.join(ctx.attr.path, "/lib")
+    ctx.symlink(lib, "lib")
 
 dotnet_local_sdk = repository_rule(
     _dotnet_local_sdk_impl,
@@ -109,36 +109,35 @@ dotnet_local_sdk = repository_rule(
 """See /dotnet/toolchains.rst#dotnet-sdk for full documentation."""
 
 def _remote_sdk(ctx, urls, strip_prefix, sha256):
-  ctx.download_and_extract(
-      url = urls,
-      stripPrefix = strip_prefix,
-      sha256 = sha256,
-  )
-  
-def _sdk_build_file(ctx):
-  ctx.file("ROOT")
-  ctx.template("BUILD.bazel",
-      Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.sdk.bazel"),
-      executable = False,
-  )
+    ctx.download_and_extract(
+        url = urls,
+        stripPrefix = strip_prefix,
+        sha256 = sha256,
+    )
 
+def _sdk_build_file(ctx):
+    ctx.file("ROOT")
+    ctx.template(
+        "BUILD.bazel",
+        Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.sdk.bazel"),
+        executable = False,
+    )
 
 def _detect_host_sdk(ctx):
-  mcs = ctx.which("mcs" + bat_extension(ctx))
-  if not mcs:
-    defmono = ctx.path("c:/program files/mono/bin")
-    if defmono.exists:
-      mcs = ctx.path("c:/program files/mono/bin/mcs")
-    else:
-      fail("Failed to find mcs")
-  
-  mono = ctx.which("mono" + executable_extension(ctx))
-  if not mono:
-    defmono = ctx.path("c:/program files/mono/bin")
-    if defmono.exists:
-      mono = ctx.path("c:/program files/mono/bin/mono.exe")
-    else:
-      fail("Failed to find mono")
+    mcs = ctx.which("mcs" + bat_extension(ctx))
+    if not mcs:
+        defmono = ctx.path("c:/program files/mono/bin")
+        if defmono.exists:
+            mcs = ctx.path("c:/program files/mono/bin/mcs")
+        else:
+            fail("Failed to find mcs")
 
-  return (mono, mcs)
+    mono = ctx.which("mono" + executable_extension(ctx))
+    if not mono:
+        defmono = ctx.path("c:/program files/mono/bin")
+        if defmono.exists:
+            mono = ctx.path("c:/program files/mono/bin/mono.exe")
+        else:
+            fail("Failed to find mono")
 
+    return (mono, mcs)

--- a/dotnet/private/sdk_core.bzl
+++ b/dotnet/private/sdk_core.bzl
@@ -1,35 +1,35 @@
-load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "executable_extension", "bat_extension", "paths")
+load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "bat_extension", "executable_extension", "paths")
 
 def _get_shared_dir(ctx):
-  p = ctx.path("core/shared/Microsoft.NETCore.App")
-  content = p.readdir()
-  for c in content:
-    result = c.get_child("System.dll")
-    if result.exists:
-      return c
+    p = ctx.path("core/shared/Microsoft.NETCore.App")
+    content = p.readdir()
+    for c in content:
+        result = c.get_child("System.dll")
+        if result.exists:
+            return c
 
-  fail("System.dll doesn't exist in " + p)
+    fail("System.dll doesn't exist in " + p)
 
 def _core_download_sdk_impl(ctx):
-  if ctx.os.name == 'linux':
-    host = "core_linux_amd64"
-  elif ctx.os.name == 'mac os x':
-    host = "core_darwin_amd64"
-  elif ctx.os.name.startswith('windows'):
-    host = "core_windows_amd64"
-  else:
-    fail("Unsupported operating system: " + ctx.os.name)
-  sdks = ctx.attr.sdks
-  if host not in sdks: fail("Unsupported host {}".format(host))
-  filename, sha256 = ctx.attr.sdks[host]
-  _sdk_build_file(ctx)
-  _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
-  ctx.symlink("core/sdk/" + ctx.attr.version + "/Roslyn/bincore", "mcs_bin")
-  ctx.symlink("core/.", "mono_bin")
-  ctx.symlink("core/sdk/" + ctx.attr.version, "lib")
-  ctx.symlink(_get_shared_dir(ctx), "shared")
-  ctx.symlink("core/host/", "host")
-
+    if ctx.os.name == "linux":
+        host = "core_linux_amd64"
+    elif ctx.os.name == "mac os x":
+        host = "core_darwin_amd64"
+    elif ctx.os.name.startswith("windows"):
+        host = "core_windows_amd64"
+    else:
+        fail("Unsupported operating system: " + ctx.os.name)
+    sdks = ctx.attr.sdks
+    if host not in sdks:
+        fail("Unsupported host {}".format(host))
+    filename, sha256 = ctx.attr.sdks[host]
+    _sdk_build_file(ctx)
+    _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
+    ctx.symlink("core/sdk/" + ctx.attr.version + "/Roslyn/bincore", "mcs_bin")
+    ctx.symlink("core/.", "mono_bin")
+    ctx.symlink("core/sdk/" + ctx.attr.version, "lib")
+    ctx.symlink(_get_shared_dir(ctx), "shared")
+    ctx.symlink("core/host/", "host")
 
 core_download_sdk = repository_rule(
     _core_download_sdk_impl,
@@ -44,18 +44,17 @@ core_download_sdk = repository_rule(
 """See /dotnet/toolchains.rst#dotnet-sdk for full documentation."""
 
 def _remote_sdk(ctx, urls, strip_prefix, sha256):
-  ctx.download_and_extract(
-      url = urls,
-      stripPrefix = strip_prefix,
-      sha256 = sha256,
-      output="core",
-  )
-  
+    ctx.download_and_extract(
+        url = urls,
+        stripPrefix = strip_prefix,
+        sha256 = sha256,
+        output = "core",
+    )
+
 def _sdk_build_file(ctx):
-  ctx.file("ROOT")
-  ctx.template("BUILD.bazel",
-      Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.sdk.bazel"),
-      executable = False,
-  )
-
-
+    ctx.file("ROOT")
+    ctx.template(
+        "BUILD.bazel",
+        Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.sdk.bazel"),
+        executable = False,
+    )

--- a/dotnet/private/sdk_net.bzl
+++ b/dotnet/private/sdk_net.bzl
@@ -1,51 +1,49 @@
-load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "executable_extension", "bat_extension", "paths")
-
+load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "bat_extension", "executable_extension", "paths")
 
 def _detect_net_framework(ctx, version):
-  defpath = ctx.path("C:/Program Files (x86)/Reference Assemblies/Microsoft/Framework/.NETFramework/v" + version)
-  if defpath.exists:
-    return defpath
-  fail("Failed to find .net " + version + " in default location " + str(defpath))
+    defpath = ctx.path("C:/Program Files (x86)/Reference Assemblies/Microsoft/Framework/.NETFramework/v" + version)
+    if defpath.exists:
+        return defpath
+    fail("Failed to find .net " + version + " in default location " + str(defpath))
 
 def _detect_net_tools(ctx, version):
-  ms_sdk_versions = ["v8.0A", "v8.1", "v8.1A", "v10.0A"]
-  for ms_sdk_version in ms_sdk_versions:
-    defpath = ctx.path("C:/Program Files (x86)/Microsoft SDKs/Windows/" + ms_sdk_version + "/bin/NETFX " + version + " Tools")
-    if defpath.exists:
-      return defpath
-  fail("Failed to find .net tools " + version + " in default location " + defpath)
-
+    ms_sdk_versions = ["v8.0A", "v8.1", "v8.1A", "v10.0A"]
+    for ms_sdk_version in ms_sdk_versions:
+        defpath = ctx.path("C:/Program Files (x86)/Microsoft SDKs/Windows/" + ms_sdk_version + "/bin/NETFX " + version + " Tools")
+        if defpath.exists:
+            return defpath
+    fail("Failed to find .net tools " + version + " in default location " + defpath)
 
 def _net_download_sdk_impl(ctx):
-  if not ctx.os.name.startswith('windows'):
-    _net_empty_download_sdk_impl(ctx)
-    return
+    if not ctx.os.name.startswith("windows"):
+        _net_empty_download_sdk_impl(ctx)
+        return
 
-  host = "net_windows_amd64"
+    host = "net_windows_amd64"
 
-  sdks = ctx.attr.sdks
-  if host not in sdks: fail("Unsupported host {}".format(host))
-  filename, sha256 = ctx.attr.sdks[host]
-  _sdk_build_file(ctx)
-  _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
+    sdks = ctx.attr.sdks
+    if host not in sdks:
+        fail("Unsupported host {}".format(host))
+    filename, sha256 = ctx.attr.sdks[host]
+    _sdk_build_file(ctx)
+    _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
 
-  ctx.symlink("net/tools", "mcs_bin")
-  ctx.symlink("net/tools", "mono_bin")
+    ctx.symlink("net/tools", "mcs_bin")
+    ctx.symlink("net/tools", "mono_bin")
 
-  lib = _detect_net_framework(ctx, ctx.attr.version)
-  ctx.symlink(lib, "lib")
+    lib = _detect_net_framework(ctx, ctx.attr.version)
+    ctx.symlink(lib, "lib")
 
-  tools = _detect_net_tools(ctx, ctx.attr.version)
-  ctx.symlink(tools, "tools")
-
+    tools = _detect_net_tools(ctx, ctx.attr.version)
+    ctx.symlink(tools, "tools")
 
 def _net_empty_download_sdk_impl(ctx):
-  sdks = ctx.attr.sdks
-  _sdk_build_file(ctx)
-  ctx.symlink("net/tools", "mcs_bin")
-  ctx.symlink("net/tools", "mono_bin")
-  ctx.symlink("net/tools", "lib")
-  ctx.symlink("net/tools", "tools")
+    sdks = ctx.attr.sdks
+    _sdk_build_file(ctx)
+    ctx.symlink("net/tools", "mcs_bin")
+    ctx.symlink("net/tools", "mono_bin")
+    ctx.symlink("net/tools", "lib")
+    ctx.symlink("net/tools", "tools")
 
 net_download_sdk = repository_rule(
     _net_download_sdk_impl,
@@ -60,19 +58,18 @@ net_download_sdk = repository_rule(
 """See /dotnet/toolchains.rst#dotnet-sdk for full documentation."""
 
 def _remote_sdk(ctx, urls, strip_prefix, sha256):
-  ctx.download_and_extract(
-      url = urls,
-      stripPrefix = strip_prefix,
-      sha256 = sha256,
-      output="net",
-      type="zip",
-  )
-  
+    ctx.download_and_extract(
+        url = urls,
+        stripPrefix = strip_prefix,
+        sha256 = sha256,
+        output = "net",
+        type = "zip",
+    )
+
 def _sdk_build_file(ctx):
-  ctx.file("ROOT")
-  ctx.template("BUILD.bazel",
-      Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.net.bazel"),
-      executable = False,
-  )
-
-
+    ctx.file("ROOT")
+    ctx.template(
+        "BUILD.bazel",
+        Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.net.bazel"),
+        executable = False,
+    )

--- a/dotnet/private/skylib/lib/collections.bzl
+++ b/dotnet/private/skylib/lib/collections.bzl
@@ -14,57 +14,53 @@
 
 """Skylib module containing functions that operate on collections."""
 
-
 def _after_each(separator, iterable):
-  """Inserts `separator` after each item in `iterable`.
+    """Inserts `separator` after each item in `iterable`.
 
-  Args:
-    separator: The value to insert after each item in `iterable`.
-    iterable: The list into which to intersperse the separator.
-  Returns:
-    A new list with `separator` after each item in `iterable`.
-  """
-  result = []
-  for x in iterable:
-    result.append(x)
-    result.append(separator)
+    Args:
+      separator: The value to insert after each item in `iterable`.
+      iterable: The list into which to intersperse the separator.
+    Returns:
+      A new list with `separator` after each item in `iterable`.
+    """
+    result = []
+    for x in iterable:
+        result.append(x)
+        result.append(separator)
 
-  return result
-
+    return result
 
 def _before_each(separator, iterable):
-  """Inserts `separator` before each item in `iterable`.
+    """Inserts `separator` before each item in `iterable`.
 
-  Args:
-    separator: The value to insert before each item in `iterable`.
-    iterable: The list into which to intersperse the separator.
-  Returns:
-    A new list with `separator` before each item in `iterable`.
-  """
-  result = []
-  for x in iterable:
-    result.append(separator)
-    result.append(x)
+    Args:
+      separator: The value to insert before each item in `iterable`.
+      iterable: The list into which to intersperse the separator.
+    Returns:
+      A new list with `separator` before each item in `iterable`.
+    """
+    result = []
+    for x in iterable:
+        result.append(separator)
+        result.append(x)
 
-  return result
-
+    return result
 
 def _uniq(iterable):
-  """Returns a list of unique elements in `iterable`.
+    """Returns a list of unique elements in `iterable`.
 
-  Requires all the elements to be hashable.
+    Requires all the elements to be hashable.
 
-  Args:
-    iterable: An iterable to filter.
-  Returns:
-    A new list with all unique elements from `iterable`.
-  """
-  unique_elements = {element: None for element in iterable}
-  return unique_elements.keys()
-
+    Args:
+      iterable: An iterable to filter.
+    Returns:
+      A new list with all unique elements from `iterable`.
+    """
+    unique_elements = {element: None for element in iterable}
+    return unique_elements.keys()
 
 collections = struct(
-    after_each=_after_each,
-    before_each=_before_each,
-    uniq=_uniq,
+    after_each = _after_each,
+    before_each = _before_each,
+    uniq = _uniq,
 )

--- a/dotnet/private/skylib/lib/dicts.bzl
+++ b/dotnet/private/skylib/lib/dicts.bzl
@@ -14,29 +14,27 @@
 
 """Skylib module containing functions that operate on dictionaries."""
 
-
 def _add(*dictionaries):
-  """Returns a new `dict` that has all the entries of the given dictionaries.
+    """Returns a new `dict` that has all the entries of the given dictionaries.
 
-  If the same key is present in more than one of the input dictionaries, the
-  last of them in the argument list overrides any earlier ones.
+    If the same key is present in more than one of the input dictionaries, the
+    last of them in the argument list overrides any earlier ones.
 
-  This function is designed to take zero or one arguments as well as multiple
-  dictionaries, so that it follows arithmetic identities and callers can avoid
-  special cases for their inputs: the sum of zero dictionaries is the empty
-  dictionary, and the sum of a single dictionary is a copy of itself.
+    This function is designed to take zero or one arguments as well as multiple
+    dictionaries, so that it follows arithmetic identities and callers can avoid
+    special cases for their inputs: the sum of zero dictionaries is the empty
+    dictionary, and the sum of a single dictionary is a copy of itself.
 
-  Args:
-    *dictionaries: Zero or more dictionaries to be added.
-  Returns:
-    A new `dict` that has all the entries of the given dictionaries.
-  """
-  result = {}
-  for d in dictionaries:
-    result.update(d)
-  return result
-
+    Args:
+      *dictionaries: Zero or more dictionaries to be added.
+    Returns:
+      A new `dict` that has all the entries of the given dictionaries.
+    """
+    result = {}
+    for d in dictionaries:
+        result.update(d)
+    return result
 
 dicts = struct(
-    add=_add,
+    add = _add,
 )

--- a/dotnet/private/skylib/lib/paths.bzl
+++ b/dotnet/private/skylib/lib/paths.bzl
@@ -19,227 +19,218 @@ path separators (forward slash, "/"); they do not handle Windows-style paths
 with backslash separators or drive letters.
 """
 
-
 def _basename(p):
-  """Returns the basename (i.e., the file portion) of a path.
+    """Returns the basename (i.e., the file portion) of a path.
 
-  Note that if `p` ends with a slash, this function returns an empty string.
-  This matches the behavior of Python's `os.path.basename`, but differs from
-  the Unix `basename` command (which would return the path segment preceding
-  the final slash).
+    Note that if `p` ends with a slash, this function returns an empty string.
+    This matches the behavior of Python's `os.path.basename`, but differs from
+    the Unix `basename` command (which would return the path segment preceding
+    the final slash).
 
-  Args:
-    p: The path whose basename should be returned.
-  Returns:
-    The basename of the path, which includes the extension.
-  """
-  return p.rpartition("/")[-1]
-
+    Args:
+      p: The path whose basename should be returned.
+    Returns:
+      The basename of the path, which includes the extension.
+    """
+    return p.rpartition("/")[-1]
 
 def _dirname(p):
-  """Returns the dirname of a path.
+    """Returns the dirname of a path.
 
-  The dirname is the portion of `p` up to but not including the file portion
-  (i.e., the basename). Any slashes immediately preceding the basename are not
-  included, unless omitting them would make the dirname empty.
+    The dirname is the portion of `p` up to but not including the file portion
+    (i.e., the basename). Any slashes immediately preceding the basename are not
+    included, unless omitting them would make the dirname empty.
 
-  Args:
-    p: The path whose dirname should be returned.
-  Returns:
-    The dirname of the path.
-  """
-  prefix, sep, _ = p.rpartition("/")
-  if not prefix:
-    return sep
-  else:
-    # If there are multiple consecutive slashes, strip them all out as Python's
-    # os.path.dirname does.
-    return prefix.rstrip("/")
-
+    Args:
+      p: The path whose dirname should be returned.
+    Returns:
+      The dirname of the path.
+    """
+    prefix, sep, _ = p.rpartition("/")
+    if not prefix:
+        return sep
+    else:
+        # If there are multiple consecutive slashes, strip them all out as Python's
+        # os.path.dirname does.
+        return prefix.rstrip("/")
 
 def _is_absolute(path):
-  """Returns `True` if `path` is an absolute path.
+    """Returns `True` if `path` is an absolute path.
 
-  Args:
-    path: A path (which is a string).
-  Returns:
-    `True` if `path` is an absolute path.
-  """
-  return path.startswith("/") or path[1] == ":"
-
+    Args:
+      path: A path (which is a string).
+    Returns:
+      `True` if `path` is an absolute path.
+    """
+    return path.startswith("/") or path[1] == ":"
 
 def _join(path, *others):
-  """Joins one or more path components intelligently.
+    """Joins one or more path components intelligently.
 
-  This function mimics the behavior of Python's `os.path.join` function on POSIX
-  platform. It returns the concatenation of `path` and any members of `others`,
-  inserting directory separators before each component except the first. The
-  separator is not inserted if the path up until that point is either empty or
-  already ends in a separator.
+    This function mimics the behavior of Python's `os.path.join` function on POSIX
+    platform. It returns the concatenation of `path` and any members of `others`,
+    inserting directory separators before each component except the first. The
+    separator is not inserted if the path up until that point is either empty or
+    already ends in a separator.
 
-  If any component is an absolute path, all previous components are discarded.
+    If any component is an absolute path, all previous components are discarded.
 
-  Args:
-    path: A path segment.
-    *others: Additional path segments.
-  Returns:
-    A string containing the joined paths.
-  """
-  result = path
+    Args:
+      path: A path segment.
+      *others: Additional path segments.
+    Returns:
+      A string containing the joined paths.
+    """
+    result = path
 
-  for p in others:
-    if _is_absolute(p):
-      result = p
-    elif not result or result.endswith("/"):
-      result += p
-    else:
-      result += "/" + p
+    for p in others:
+        if _is_absolute(p):
+            result = p
+        elif not result or result.endswith("/"):
+            result += p
+        else:
+            result += "/" + p
 
-  return result
-
+    return result
 
 def _normalize(path):
-  """Normalizes a path, eliminating double slashes and other redundant segments.
+    """Normalizes a path, eliminating double slashes and other redundant segments.
 
-  This function mimics the behavior of Python's `os.path.normpath` function on
-  POSIX platforms; specifically:
+    This function mimics the behavior of Python's `os.path.normpath` function on
+    POSIX platforms; specifically:
 
-  - If the entire path is empty, "." is returned.
-  - All "." segments are removed, unless the path consists solely of a single
-    "." segment.
-  - Trailing slashes are removed, unless the path consists solely of slashes.
-  - ".." segments are removed as long as there are corresponding segments
-    earlier in the path to remove; otherwise, they are retained as leading ".."
-    segments.
-  - Single and double leading slashes are preserved, but three or more leading
-    slashes are collapsed into a single leading slash.
-  - Multiple adjacent internal slashes are collapsed into a single slash.
+    - If the entire path is empty, "." is returned.
+    - All "." segments are removed, unless the path consists solely of a single
+      "." segment.
+    - Trailing slashes are removed, unless the path consists solely of slashes.
+    - ".." segments are removed as long as there are corresponding segments
+      earlier in the path to remove; otherwise, they are retained as leading ".."
+      segments.
+    - Single and double leading slashes are preserved, but three or more leading
+      slashes are collapsed into a single leading slash.
+    - Multiple adjacent internal slashes are collapsed into a single slash.
 
-  Args:
-    path: A path.
-  Returns:
-    The normalized path.
-  """
-  if not path:
-    return "."
+    Args:
+      path: A path.
+    Returns:
+      The normalized path.
+    """
+    if not path:
+        return "."
 
-  if path.startswith("//") and not path.startswith("///"):
-    initial_slashes = 2
-  elif path.startswith("/"):
-    initial_slashes = 1
-  else:
-    initial_slashes = 0
-  is_relative = (initial_slashes == 0)
-
-  components = path.split("/")
-  new_components = []
-
-  for component in components:
-    if component in ("", "."):
-      continue
-    if component == "..":
-      if new_components and new_components[-1] != "..":
-        # Only pop the last segment if it isn't another "..".
-        new_components.pop()
-      elif is_relative:
-        # Preserve leading ".." segments for relative paths.
-        new_components.append(component)
+    if path.startswith("//") and not path.startswith("///"):
+        initial_slashes = 2
+    elif path.startswith("/"):
+        initial_slashes = 1
     else:
-      new_components.append(component)
+        initial_slashes = 0
+    is_relative = (initial_slashes == 0)
 
-  path = "/".join(new_components)
-  if not is_relative:
-    path = ("/" * initial_slashes) + path
+    components = path.split("/")
+    new_components = []
 
-  return path or "."
+    for component in components:
+        if component in ("", "."):
+            continue
+        if component == "..":
+            if new_components and new_components[-1] != "..":
+                # Only pop the last segment if it isn't another "..".
+                new_components.pop()
+            elif is_relative:
+                # Preserve leading ".." segments for relative paths.
+                new_components.append(component)
+        else:
+            new_components.append(component)
 
+    path = "/".join(new_components)
+    if not is_relative:
+        path = ("/" * initial_slashes) + path
+
+    return path or "."
 
 def _relativize(path, start):
-  """Returns the portion of `path` that is relative to `start`.
+    """Returns the portion of `path` that is relative to `start`.
 
-  Because we do not have access to the underlying file system, this
-  implementation differs slightly from Python's `os.path.relpath` in that it
-  will fail if `path` is not beneath `start` (rather than use parent segments to
-  walk up to the common file system root).
+    Because we do not have access to the underlying file system, this
+    implementation differs slightly from Python's `os.path.relpath` in that it
+    will fail if `path` is not beneath `start` (rather than use parent segments to
+    walk up to the common file system root).
 
-  Relativizing paths that start with parent directory references is not allowed.
+    Relativizing paths that start with parent directory references is not allowed.
 
-  Args:
-    path: The path to relativize.
-    start: The ancestor path against which to relativize.
-  Returns:
-    The portion of `path` that is relative to `start`.
-  """
-  segments = _normalize(path).split("/")
-  start_segments = _normalize(start).split("/")
-  if start_segments == ["."]:
-    start_segments = []
-  start_length = len(start_segments)
+    Args:
+      path: The path to relativize.
+      start: The ancestor path against which to relativize.
+    Returns:
+      The portion of `path` that is relative to `start`.
+    """
+    segments = _normalize(path).split("/")
+    start_segments = _normalize(start).split("/")
+    if start_segments == ["."]:
+        start_segments = []
+    start_length = len(start_segments)
 
-  if (path.startswith("..") or start.startswith("..")):
-    fail("Cannot relativize paths above the current (unknown) directory")
+    if (path.startswith("..") or start.startswith("..")):
+        fail("Cannot relativize paths above the current (unknown) directory")
 
-  if (path.startswith("/") != start.startswith("/") or
-      len(segments) < start_length):
-    fail("Path '%s' is not beneath '%s'" % (path, start))
+    if (path.startswith("/") != start.startswith("/") or
+        len(segments) < start_length):
+        fail("Path '%s' is not beneath '%s'" % (path, start))
 
-  for ancestor_segment, segment in zip(start_segments, segments):
-    if ancestor_segment != segment:
-      fail("Path '%s' is not beneath '%s'" % (path, start))
+    for ancestor_segment, segment in zip(start_segments, segments):
+        if ancestor_segment != segment:
+            fail("Path '%s' is not beneath '%s'" % (path, start))
 
-  length = len(segments) - start_length
-  result_segments = segments[-length:]
-  return "/".join(result_segments)
-
+    length = len(segments) - start_length
+    result_segments = segments[-length:]
+    return "/".join(result_segments)
 
 def _replace_extension(p, new_extension):
-  """Replaces the extension of the file at the end of a path.
+    """Replaces the extension of the file at the end of a path.
 
-  If the path has no extension, the new extension is added to it.
+    If the path has no extension, the new extension is added to it.
 
-  Args:
-    p: The path whose extension should be replaced.
-    new_extension: The new extension for the file. The new extension should
-        begin with a dot if you want the new filename to have one.
-  Returns:
-    The path with the extension replaced (or added, if it did not have one).
-  """
-  return _split_extension(p)[0] + new_extension
-
+    Args:
+      p: The path whose extension should be replaced.
+      new_extension: The new extension for the file. The new extension should
+          begin with a dot if you want the new filename to have one.
+    Returns:
+      The path with the extension replaced (or added, if it did not have one).
+    """
+    return _split_extension(p)[0] + new_extension
 
 def _split_extension(p):
-  """Splits the path `p` into a tuple containing the root and extension.
+    """Splits the path `p` into a tuple containing the root and extension.
 
-  Leading periods on the basename are ignored, so
-  `path.split_extension(".bashrc")` returns `(".bashrc", "")`.
+    Leading periods on the basename are ignored, so
+    `path.split_extension(".bashrc")` returns `(".bashrc", "")`.
 
-  Args:
-    p: The path whose root and extension should be split.
-  Returns:
-    A tuple `(root, ext)` such that the root is the path without the file
-    extension, and `ext` is the file extension (which, if non-empty, contains
-    the leading dot). The returned tuple always satisfies the relationship
-    `root + ext == p`.
-  """
-  b = _basename(p)
-  last_dot_in_basename = b.rfind(".")
+    Args:
+      p: The path whose root and extension should be split.
+    Returns:
+      A tuple `(root, ext)` such that the root is the path without the file
+      extension, and `ext` is the file extension (which, if non-empty, contains
+      the leading dot). The returned tuple always satisfies the relationship
+      `root + ext == p`.
+    """
+    b = _basename(p)
+    last_dot_in_basename = b.rfind(".")
 
-  # If there is no dot or the only dot in the basename is at the front, then
-  # there is no extension.
-  if last_dot_in_basename <= 0:
-    return (p, "")
+    # If there is no dot or the only dot in the basename is at the front, then
+    # there is no extension.
+    if last_dot_in_basename <= 0:
+        return (p, "")
 
-  dot_distance_from_end = len(b) - last_dot_in_basename
-  return (p[:-dot_distance_from_end], p[-dot_distance_from_end:])
-
+    dot_distance_from_end = len(b) - last_dot_in_basename
+    return (p[:-dot_distance_from_end], p[-dot_distance_from_end:])
 
 paths = struct(
-    basename=_basename,
-    dirname=_dirname,
-    is_absolute=_is_absolute,
-    join=_join,
-    normalize=_normalize,
-    relativize=_relativize,
-    replace_extension=_replace_extension,
-    split_extension=_split_extension,
+    basename = _basename,
+    dirname = _dirname,
+    is_absolute = _is_absolute,
+    join = _join,
+    normalize = _normalize,
+    relativize = _relativize,
+    replace_extension = _replace_extension,
+    split_extension = _split_extension,
 )

--- a/dotnet/private/skylib/lib/selects.bzl
+++ b/dotnet/private/skylib/lib/selects.bzl
@@ -15,69 +15,67 @@
 """Skylib module containing convenience interfaces for select()."""
 
 def _with_or(input_dict):
-  """Drop-in replacement for `select()` that supports ORed keys.
+    """Drop-in replacement for `select()` that supports ORed keys.
 
-  Args:
-    input_dict: The same dictionary `select()` takes, except keys may take
-        either the usual form `"//foo:config1"` or
-        `("//foo:config1", "//foo:config2", ...)` to signify
-        `//foo:config1` OR `//foo:config2` OR `...`.
+    Args:
+      input_dict: The same dictionary `select()` takes, except keys may take
+          either the usual form `"//foo:config1"` or
+          `("//foo:config1", "//foo:config2", ...)` to signify
+          `//foo:config1` OR `//foo:config2` OR `...`.
 
-        Example:
+          Example:
 
-        ```build
-        deps = selects.with_or({
-            "//configs:one": [":dep1"],
-            ("//configs:two", "//configs:three"): [":dep2or3"],
-            "//configs:four": [":dep4"],
-            "//conditions:default": [":default"]
-        })
-        ```
+          ```build
+          deps = selects.with_or({
+              "//configs:one": [":dep1"],
+              ("//configs:two", "//configs:three"): [":dep2or3"],
+              "//configs:four": [":dep4"],
+              "//conditions:default": [":default"]
+          })
+          ```
 
-        Key labels may appear at most once anywhere in the input.
+          Key labels may appear at most once anywhere in the input.
 
-  Returns:
-    A native `select()` that expands
+    Returns:
+      A native `select()` that expands
 
-    `("//configs:two", "//configs:three"): [":dep2or3"]`
+      `("//configs:two", "//configs:three"): [":dep2or3"]`
 
-    to
+      to
 
-    ```build
-    "//configs:two": [":dep2or3"],
-    "//configs:three": [":dep2or3"],
-    ```
-  """
-  return select(_with_or_dict(input_dict))
-
+      ```build
+      "//configs:two": [":dep2or3"],
+      "//configs:three": [":dep2or3"],
+      ```
+    """
+    return select(_with_or_dict(input_dict))
 
 def _with_or_dict(input_dict):
-  """Variation of `with_or` that returns the dict of the `select()`.
+    """Variation of `with_or` that returns the dict of the `select()`.
 
-  Unlike `select()`, the contents of the dict can be inspected by Skylark
-  macros.
+    Unlike `select()`, the contents of the dict can be inspected by Skylark
+    macros.
 
-  Args:
-    input_dict: Same as `with_or`.
+    Args:
+      input_dict: Same as `with_or`.
 
-  Returns:
-    A dictionary usable by a native `select()`.
-  """
-  output_dict = {}
-  for (key, value) in input_dict.items():
-    if type(key) == type(()):
-      for config_setting in key:
-        if config_setting in output_dict.keys():
-          fail("key %s appears multiple times" % config_setting)
-        output_dict[config_setting] = value
-    else:
-      if key in output_dict.keys():
-        fail("key %s appears multiple times" % config_setting)
-      output_dict[key] = value
-  return output_dict
-
+    Returns:
+      A dictionary usable by a native `select()`.
+    """
+    output_dict = {}
+    for (key, value) in input_dict.items():
+        if type(key) == type(()):
+            for config_setting in key:
+                if config_setting in output_dict.keys():
+                    fail("key %s appears multiple times" % config_setting)
+                output_dict[config_setting] = value
+        else:
+            if key in output_dict.keys():
+                fail("key %s appears multiple times" % config_setting)
+            output_dict[key] = value
+    return output_dict
 
 selects = struct(
-    with_or=_with_or,
-    with_or_dict=_with_or_dict
+    with_or = _with_or,
+    with_or_dict = _with_or_dict,
 )

--- a/dotnet/private/skylib/lib/sets.bzl
+++ b/dotnet/private/skylib/lib/sets.bzl
@@ -26,114 +26,106 @@ duplicate elements are ignored). Functions that return new sets always return
 them as the `set` type, regardless of the types of the inputs.
 """
 
-
 def _precondition_only_sets_or_lists(*args):
-  """Verifies that all arguments are either sets or lists.
+    """Verifies that all arguments are either sets or lists.
 
-  The build will fail if any of the arguments is neither a set nor a list.
+    The build will fail if any of the arguments is neither a set nor a list.
 
-  Args:
-    *args: A list of values that must be sets or lists.
-  """
-  for a in args:
-    t = type(a)
-    if t not in("depset", "list"):
-      fail("Expected arguments to be depset or list, but found type %s: %r" %
-           (t, a))
-
+    Args:
+      *args: A list of values that must be sets or lists.
+    """
+    for a in args:
+        t = type(a)
+        if t not in ("depset", "list"):
+            fail("Expected arguments to be depset or list, but found type %s: %r" %
+                 (t, a))
 
 def _is_equal(a, b):
-  """Returns whether two sets are equal.
+    """Returns whether two sets are equal.
 
-  Args:
-    a: A depset or a list.
-    b: A depset or a list.
-  Returns:
-    True if `a` is equal to `b`, False otherwise.
-  """
-  _precondition_only_sets_or_lists(a, b)
-  return sorted(depset(a)) == sorted(depset(b))
-
+    Args:
+      a: A depset or a list.
+      b: A depset or a list.
+    Returns:
+      True if `a` is equal to `b`, False otherwise.
+    """
+    _precondition_only_sets_or_lists(a, b)
+    return sorted(depset(a)) == sorted(depset(b))
 
 def _is_subset(a, b):
-  """Returns whether `a` is a subset of `b`.
+    """Returns whether `a` is a subset of `b`.
 
-  Args:
-    a: A depset or a list.
-    b: A depset or a list.
+    Args:
+      a: A depset or a list.
+      b: A depset or a list.
 
-  Returns:
-    True if `a` is a subset of `b`, False otherwise.
-  """
-  _precondition_only_sets_or_lists(a, b)
-  for e in a:
-    if e not in b:
-      return False
-  return True
-
+    Returns:
+      True if `a` is a subset of `b`, False otherwise.
+    """
+    _precondition_only_sets_or_lists(a, b)
+    for e in a:
+        if e not in b:
+            return False
+    return True
 
 def _disjoint(a, b):
-  """Returns whether two sets are disjoint.
+    """Returns whether two sets are disjoint.
 
-  Two sets are disjoint if they have no elements in common.
+    Two sets are disjoint if they have no elements in common.
 
-  Args:
-    a: A set or list.
-    b: A set or list.
+    Args:
+      a: A set or list.
+      b: A set or list.
 
-  Returns:
-    True if `a` and `b` are disjoint, False otherwise.
-  """
-  _precondition_only_sets_or_lists(a, b)
-  for e in a:
-    if e in b:
-      return False
-  return True
-
+    Returns:
+      True if `a` and `b` are disjoint, False otherwise.
+    """
+    _precondition_only_sets_or_lists(a, b)
+    for e in a:
+        if e in b:
+            return False
+    return True
 
 def _intersection(a, b):
-  """Returns the intersection of two sets.
+    """Returns the intersection of two sets.
 
-  Args:
-    a: A set or list.
-    b: A set or list.
+    Args:
+      a: A set or list.
+      b: A set or list.
 
-  Returns:
-    A set containing the elements that are in both `a` and `b`.
-  """
-  _precondition_only_sets_or_lists(a, b)
-  return depset([e for e in a if e in b])
-
+    Returns:
+      A set containing the elements that are in both `a` and `b`.
+    """
+    _precondition_only_sets_or_lists(a, b)
+    return depset([e for e in a if e in b])
 
 def _union(*args):
-  """Returns the union of several sets.
+    """Returns the union of several sets.
 
-  Args:
-    *args: An arbitrary number of sets or lists.
+    Args:
+      *args: An arbitrary number of sets or lists.
 
-  Returns:
-    The set union of all sets or lists in `*args`.
-  """
-  _precondition_only_sets_or_lists(*args)
-  r = depset()
-  for a in args:
-    r += a
-  return r
-
+    Returns:
+      The set union of all sets or lists in `*args`.
+    """
+    _precondition_only_sets_or_lists(*args)
+    r = depset()
+    for a in args:
+        r += a
+    return r
 
 def _difference(a, b):
-  """Returns the elements in `a` that are not in `b`.
+    """Returns the elements in `a` that are not in `b`.
 
-  Args:
-    a: A set or list.
-    b: A set or list.
+    Args:
+      a: A set or list.
+      b: A set or list.
 
-  Returns:
-    A set containing the elements that are in `a` but not in `b`.
-  """
-  _precondition_only_sets_or_lists(a, b)
-  return depset([e for e in a if e not in b])
-
+    Returns:
+      A set containing the elements that are in `a` but not in `b`.
+    """
+    _precondition_only_sets_or_lists(a, b)
+    return depset([e for e in a if e not in b])
 
 sets = struct(
     difference = _difference,

--- a/dotnet/private/skylib/lib/shell.bzl
+++ b/dotnet/private/skylib/lib/shell.bzl
@@ -14,42 +14,39 @@
 
 """Skylib module containing shell utility functions."""
 
-
 def _array_literal(iterable):
-  """Creates a string from a sequence that can be used as a shell array.
+    """Creates a string from a sequence that can be used as a shell array.
 
-  For example, `shell.array_literal(["a", "b", "c"])` would return the string
-  `("a" "b" "c")`, which can be used in a shell script wherever an array
-  literal is needed.
+    For example, `shell.array_literal(["a", "b", "c"])` would return the string
+    `("a" "b" "c")`, which can be used in a shell script wherever an array
+    literal is needed.
 
-  Note that all elements in the array are quoted (using `shell.quote`) for
-  safety, even if they do not need to be.
+    Note that all elements in the array are quoted (using `shell.quote`) for
+    safety, even if they do not need to be.
 
-  Args:
-    iterable: A sequence of elements. Elements that are not strings will be
-        converted to strings first, by calling `str()`.
-  Returns:
-    A string that represents the sequence as a shell array; that is,
-    parentheses containing the quoted elements.
-  """
-  return "(" + " ".join([_quote(str(i)) for i in iterable]) + ")"
-
+    Args:
+      iterable: A sequence of elements. Elements that are not strings will be
+          converted to strings first, by calling `str()`.
+    Returns:
+      A string that represents the sequence as a shell array; that is,
+      parentheses containing the quoted elements.
+    """
+    return "(" + " ".join([_quote(str(i)) for i in iterable]) + ")"
 
 def _quote(s):
-  """Quotes the given string for use in a shell command.
+    """Quotes the given string for use in a shell command.
 
-  This function quotes the given string (in case it contains spaces or other
-  shell metacharacters.)
+    This function quotes the given string (in case it contains spaces or other
+    shell metacharacters.)
 
-  Args:
-    s: The string to quote.
-  Returns:
-    A quoted version of the string that can be passed to a shell command.
-  """
-  return "'" + s.replace("'", "'\\''") + "'"
-
+    Args:
+      s: The string to quote.
+    Returns:
+      A quoted version of the string that can be passed to a shell command.
+    """
+    return "'" + s.replace("'", "'\\''") + "'"
 
 shell = struct(
-    array_literal=_array_literal,
-    quote=_quote,
+    array_literal = _array_literal,
+    quote = _quote,
 )

--- a/dotnet/private/skylib/lib/structs.bzl
+++ b/dotnet/private/skylib/lib/structs.bzl
@@ -14,23 +14,21 @@
 
 """Skylib module containing functions that operate on structs."""
 
-
 def _to_dict(s):
-  """Converts a `struct` to a `dict`.
+    """Converts a `struct` to a `dict`.
 
-  Args:
-    s: A `struct`.
-  Returns:
-    A `dict` whose keys and values are the same as the fields in `s`. The
-    transformation is only applied to the struct's fields and not to any
-    nested values.
-  """
-  attributes = dir(s)
-  attributes.remove("to_json")
-  attributes.remove("to_proto")
-  return {key: getattr(s, key) for key in attributes}
-
+    Args:
+      s: A `struct`.
+    Returns:
+      A `dict` whose keys and values are the same as the fields in `s`. The
+      transformation is only applied to the struct's fields and not to any
+      nested values.
+    """
+    attributes = dir(s)
+    attributes.remove("to_json")
+    attributes.remove("to_proto")
+    return {key: getattr(s, key) for key in attributes}
 
 structs = struct(
-    to_dict=_to_dict,
+    to_dict = _to_dict,
 )

--- a/dotnet/private/skylib/lib/unittest.bzl
+++ b/dotnet/private/skylib/lib/unittest.bzl
@@ -21,250 +21,242 @@ assertions used to within tests.
 
 load(":sets.bzl", "sets")
 
+def _make(impl, attrs = None):
+    """Creates a unit test rule from its implementation function.
 
-def _make(impl, attrs=None):
-  """Creates a unit test rule from its implementation function.
+    Each unit test is defined in an implementation function that must then be
+    associated with a rule so that a target can be built. This function handles
+    the boilerplate to create and return a test rule and captures the
+    implementation function's name so that it can be printed in test feedback.
 
-  Each unit test is defined in an implementation function that must then be
-  associated with a rule so that a target can be built. This function handles
-  the boilerplate to create and return a test rule and captures the
-  implementation function's name so that it can be printed in test feedback.
+    The optional `attrs` argument can be used to define dependencies for this
+    test, in order to form unit tests of rules.
 
-  The optional `attrs` argument can be used to define dependencies for this
-  test, in order to form unit tests of rules.
+    An example of a unit test:
 
-  An example of a unit test:
+    ```
+    def _your_test(ctx):
+      env = unittest.begin(ctx)
 
-  ```
-  def _your_test(ctx):
-    env = unittest.begin(ctx)
+      # Assert statements go here
 
-    # Assert statements go here
+      unittest.end(env)
 
-    unittest.end(env)
+    your_test = unittest.make(_your_test)
+    ```
 
-  your_test = unittest.make(_your_test)
-  ```
+    Recall that names of test rules must end in `_test`.
 
-  Recall that names of test rules must end in `_test`.
+    Args:
+      impl: The implementation function of the unit test.
+      attrs: An optional dictionary to supplement the attrs passed to the
+          unit test's `rule()` constructor.
+    Returns:
+      A rule definition that should be stored in a global whose name ends in
+      `_test`.
+    """
 
-  Args:
-    impl: The implementation function of the unit test.
-    attrs: An optional dictionary to supplement the attrs passed to the
-        unit test's `rule()` constructor.
-  Returns:
-    A rule definition that should be stored in a global whose name ends in
-    `_test`.
-  """
+    # Derive the name of the implementation function for better test feedback.
+    # Skylark currently stringifies a function as "<function NAME>", so we use
+    # that knowledge to parse the "NAME" portion out. If this behavior ever
+    # changes, we'll need to update this.
+    # TODO(bazel-team): Expose a ._name field on functions to avoid this.
+    impl_name = str(impl)
+    impl_name = impl_name.partition("<function ")[-1]
+    impl_name = impl_name.rpartition(">")[0]
 
-  # Derive the name of the implementation function for better test feedback.
-  # Skylark currently stringifies a function as "<function NAME>", so we use
-  # that knowledge to parse the "NAME" portion out. If this behavior ever
-  # changes, we'll need to update this.
-  # TODO(bazel-team): Expose a ._name field on functions to avoid this.
-  impl_name = str(impl)
-  impl_name = impl_name.partition("<function ")[-1]
-  impl_name = impl_name.rpartition(">")[0]
+    attrs = dict(attrs) if attrs else {}
+    attrs["_impl_name"] = attr.string(default = impl_name)
 
-  attrs = dict(attrs) if attrs else {}
-  attrs["_impl_name"] = attr.string(default=impl_name)
-
-  return rule(
-      impl,
-      attrs=attrs,
-      _skylark_testable=True,
-      test=True,
-  )
-
+    return rule(
+        impl,
+        attrs = attrs,
+        _skylark_testable = True,
+        test = True,
+    )
 
 def _suite(name, *test_rules):
-  """Defines a `test_suite` target that contains multiple tests.
+    """Defines a `test_suite` target that contains multiple tests.
 
-  After defining your test rules in a `.bzl` file, you need to create targets
-  from those rules so that `blaze test` can execute them. Doing this manually
-  in a BUILD file would consist of listing each test in your `load` statement
-  and then creating each target one by one. To reduce duplication, we recommend
-  writing a macro in your `.bzl` file to instantiate all targets, and calling
-  that macro from your BUILD file so you only have to load one symbol.
+    After defining your test rules in a `.bzl` file, you need to create targets
+    from those rules so that `blaze test` can execute them. Doing this manually
+    in a BUILD file would consist of listing each test in your `load` statement
+    and then creating each target one by one. To reduce duplication, we recommend
+    writing a macro in your `.bzl` file to instantiate all targets, and calling
+    that macro from your BUILD file so you only have to load one symbol.
 
-  For the case where your unit tests do not take any (non-default) attributes --
-  i.e., if your unit tests do not test rules -- you can use this function to
-  create the targets and wrap them in a single test_suite target. In your
-  `.bzl` file, write:
+    For the case where your unit tests do not take any (non-default) attributes --
+    i.e., if your unit tests do not test rules -- you can use this function to
+    create the targets and wrap them in a single test_suite target. In your
+    `.bzl` file, write:
 
-  ```
-  def your_test_suite():
-    unittest.suite(
-        "your_test_suite",
-        your_test,
-        your_other_test,
-        yet_another_test,
+    ```
+    def your_test_suite():
+      unittest.suite(
+          "your_test_suite",
+          your_test,
+          your_other_test,
+          yet_another_test,
+      )
+    ```
+
+    Then, in your `BUILD` file, simply load the macro and invoke it to have all
+    of the targets created:
+
+    ```
+    load("//path/to/your/package:tests.bzl", "your_test_suite")
+    your_test_suite()
+    ```
+
+    If you pass _N_ unit test rules to `unittest.suite`, _N_ + 1 targets will be
+    created: a `test_suite` target named `${name}` (where `${name}` is the name
+    argument passed in here) and targets named `${name}_test_${i}`, where `${i}`
+    is the index of the test in the `test_rules` list, which is used to uniquely
+    name each target.
+
+    Args:
+      name: The name of the `test_suite` target, and the prefix of all the test
+          target names.
+      *test_rules: A list of test rules defines by `unittest.test`.
+    """
+    test_names = []
+    for index, test_rule in enumerate(test_rules):
+        test_name = "%s_test_%d" % (name, index)
+        test_rule(name = test_name)
+        test_names.append(test_name)
+
+    native.test_suite(
+        name = name,
+        tests = [":%s" % t for t in test_names],
     )
-  ```
-
-  Then, in your `BUILD` file, simply load the macro and invoke it to have all
-  of the targets created:
-
-  ```
-  load("//path/to/your/package:tests.bzl", "your_test_suite")
-  your_test_suite()
-  ```
-
-  If you pass _N_ unit test rules to `unittest.suite`, _N_ + 1 targets will be
-  created: a `test_suite` target named `${name}` (where `${name}` is the name
-  argument passed in here) and targets named `${name}_test_${i}`, where `${i}`
-  is the index of the test in the `test_rules` list, which is used to uniquely
-  name each target.
-
-  Args:
-    name: The name of the `test_suite` target, and the prefix of all the test
-        target names.
-    *test_rules: A list of test rules defines by `unittest.test`.
-  """
-  test_names = []
-  for index, test_rule in enumerate(test_rules):
-    test_name = "%s_test_%d" % (name, index)
-    test_rule(name=test_name)
-    test_names.append(test_name)
-
-  native.test_suite(
-      name=name,
-      tests=[":%s" % t for t in test_names]
-  )
-
 
 def _begin(ctx):
-  """Begins a unit test.
+    """Begins a unit test.
 
-  This should be the first function called in a unit test implementation
-  function. It initializes a "test environment" that is used to collect
-  assertion failures so that they can be reported and logged at the end of the
-  test.
+    This should be the first function called in a unit test implementation
+    function. It initializes a "test environment" that is used to collect
+    assertion failures so that they can be reported and logged at the end of the
+    test.
 
-  Args:
-    ctx: The Skylark context. Pass the implementation function's `ctx` argument
-        in verbatim.
-  Returns:
-    A test environment struct that must be passed to assertions and finally to
-    `unittest.end`. Do not rely on internal details about the fields in this
-    struct as it may change.
-  """
-  return struct(ctx=ctx, failures=[])
-
+    Args:
+      ctx: The Skylark context. Pass the implementation function's `ctx` argument
+          in verbatim.
+    Returns:
+      A test environment struct that must be passed to assertions and finally to
+      `unittest.end`. Do not rely on internal details about the fields in this
+      struct as it may change.
+    """
+    return struct(ctx = ctx, failures = [])
 
 def _end(env):
-  """Ends a unit test and logs the results.
+    """Ends a unit test and logs the results.
 
-  This must be called before the end of a unit test implementation function so
-  that the results are reported.
+    This must be called before the end of a unit test implementation function so
+    that the results are reported.
 
-  Args:
-    env: The test environment returned by `unittest.begin`.
-  """
-  cmd = "\n".join([
-      "cat << EOF",
-      "\n".join(env.failures),
-      "EOF",
-      "exit %d" % len(env.failures),
-  ])
-  env.ctx.file_action(
-      output=env.ctx.outputs.executable,
-      content=cmd,
-      executable=True,
-  )
-
+    Args:
+      env: The test environment returned by `unittest.begin`.
+    """
+    cmd = "\n".join([
+        "cat << EOF",
+        "\n".join(env.failures),
+        "EOF",
+        "exit %d" % len(env.failures),
+    ])
+    env.ctx.file_action(
+        output = env.ctx.outputs.executable,
+        content = cmd,
+        executable = True,
+    )
 
 def _fail(env, msg):
-  """Unconditionally causes the current test to fail.
+    """Unconditionally causes the current test to fail.
 
-  Args:
-    env: The test environment returned by `unittest.begin`.
-    msg: The message to log describing the failure.
-  """
-  full_msg = "In test %s: %s" % (env.ctx.attr._impl_name, msg)
-  print(full_msg)
-  env.failures.append(full_msg)
+    Args:
+      env: The test environment returned by `unittest.begin`.
+      msg: The message to log describing the failure.
+    """
+    full_msg = "In test %s: %s" % (env.ctx.attr._impl_name, msg)
+    print(full_msg)
+    env.failures.append(full_msg)
 
+def _assert_true(
+        env,
+        condition,
+        msg = "Expected condition to be true, but was false."):
+    """Asserts that the given `condition` is true.
 
-def _assert_true(env,
-                 condition,
-                 msg="Expected condition to be true, but was false."):
-  """Asserts that the given `condition` is true.
+    Args:
+      env: The test environment returned by `unittest.begin`.
+      condition: A value that will be evaluated in a Boolean context.
+      msg: An optional message that will be printed that describes the failure.
+          If omitted, a default will be used.
+    """
+    if not condition:
+        _fail(env, msg)
 
-  Args:
-    env: The test environment returned by `unittest.begin`.
-    condition: A value that will be evaluated in a Boolean context.
-    msg: An optional message that will be printed that describes the failure.
-        If omitted, a default will be used.
-  """
-  if not condition:
-    _fail(env, msg)
+def _assert_false(
+        env,
+        condition,
+        msg = "Expected condition to be false, but was true."):
+    """Asserts that the given `condition` is false.
 
+    Args:
+      env: The test environment returned by `unittest.begin`.
+      condition: A value that will be evaluated in a Boolean context.
+      msg: An optional message that will be printed that describes the failure.
+          If omitted, a default will be used.
+    """
+    if condition:
+        _fail(env, msg)
 
-def _assert_false(env,
-                  condition,
-                  msg="Expected condition to be false, but was true."):
-  """Asserts that the given `condition` is false.
+def _assert_equals(env, expected, actual, msg = None):
+    """Asserts that the given `expected` and `actual` values are equal.
 
-  Args:
-    env: The test environment returned by `unittest.begin`.
-    condition: A value that will be evaluated in a Boolean context.
-    msg: An optional message that will be printed that describes the failure.
-        If omitted, a default will be used.
-  """
-  if condition:
-    _fail(env, msg)
+    Args:
+      env: The test environment returned by `unittest.begin`.
+      expected: The expected value of some computation.
+      actual: The actual value returned by some computation.
+      msg: An optional message that will be printed that describes the failure.
+          If omitted, a default will be used.
+    """
+    if expected != actual:
+        expectation_msg = 'Expected "%s", but got "%s"' % (expected, actual)
+        if msg:
+            full_msg = "%s (%s)" % (msg, expectation_msg)
+        else:
+            full_msg = expectation_msg
+        _fail(env, full_msg)
 
+def _assert_set_equals(env, expected, actual, msg = None):
+    """Asserts that the given `expected` and `actual` sets are equal.
 
-def _assert_equals(env, expected, actual, msg=None):
-  """Asserts that the given `expected` and `actual` values are equal.
-
-  Args:
-    env: The test environment returned by `unittest.begin`.
-    expected: The expected value of some computation.
-    actual: The actual value returned by some computation.
-    msg: An optional message that will be printed that describes the failure.
-        If omitted, a default will be used.
-  """
-  if expected != actual:
-    expectation_msg = 'Expected "%s", but got "%s"' % (expected, actual)
-    if msg:
-      full_msg = "%s (%s)" % (msg, expectation_msg)
-    else:
-      full_msg = expectation_msg
-    _fail(env, full_msg)
-
-
-def _assert_set_equals(env, expected, actual, msg=None):
-  """Asserts that the given `expected` and `actual` sets are equal.
-
-  Args:
-    env: The test environment returned by `unittest.begin`.
-    expected: The expected set resulting from some computation.
-    actual: The actual set returned by some computation.
-    msg: An optional message that will be printed that describes the failure.
-        If omitted, a default will be used.
-  """
-  if type(actual) != type(depset()) or not sets.is_equal(expected, actual):
-    expectation_msg = "Expected %r, but got %r" % (expected, actual)
-    if msg:
-      full_msg = "%s (%s)" % (msg, expectation_msg)
-    else:
-      full_msg = expectation_msg
-    _fail(env, full_msg)
-
+    Args:
+      env: The test environment returned by `unittest.begin`.
+      expected: The expected set resulting from some computation.
+      actual: The actual set returned by some computation.
+      msg: An optional message that will be printed that describes the failure.
+          If omitted, a default will be used.
+    """
+    if type(actual) != type(depset()) or not sets.is_equal(expected, actual):
+        expectation_msg = "Expected %r, but got %r" % (expected, actual)
+        if msg:
+            full_msg = "%s (%s)" % (msg, expectation_msg)
+        else:
+            full_msg = expectation_msg
+        _fail(env, full_msg)
 
 asserts = struct(
-    equals=_assert_equals,
-    false=_assert_false,
-    set_equals=_assert_set_equals,
-    true=_assert_true,
+    equals = _assert_equals,
+    false = _assert_false,
+    set_equals = _assert_set_equals,
+    true = _assert_true,
 )
 
 unittest = struct(
-    make=_make,
-    suite=_suite,
-    begin=_begin,
-    end=_end,
-    fail=_fail,
+    make = _make,
+    suite = _suite,
+    begin = _begin,
+    end = _end,
+    fail = _fail,
 )

--- a/dotnet/private/skylib/lib/versions.bzl
+++ b/dotnet/private/skylib/lib/versions.bzl
@@ -15,112 +15,114 @@
 """Skylib module containing functions for checking Bazel versions."""
 
 def _get_bazel_version():
-  """Returns the current Bazel version"""
+    """Returns the current Bazel version"""
 
-  return native.bazel_version
-
+    return native.bazel_version
 
 def _extract_version_number(bazel_version):
-  """Extracts the semantic version number from a version string
+    """Extracts the semantic version number from a version string
 
-  Args:
-    bazel_version: the version string that begins with the semantic version
-      e.g. "1.2.3rc1 abc1234" where "abc1234" is a commit hash.
+    Args:
+      bazel_version: the version string that begins with the semantic version
+        e.g. "1.2.3rc1 abc1234" where "abc1234" is a commit hash.
 
-  Returns:
-    The semantic version string, like "1.2.3".
-  """
-  for i in range(len(bazel_version)):
-    c = bazel_version[i]
-    if not (c.isdigit() or c == "."):
-      return bazel_version[:i]
-  return bazel_version
+    Returns:
+      The semantic version string, like "1.2.3".
+    """
+    for i in range(len(bazel_version)):
+        c = bazel_version[i]
+        if not (c.isdigit() or c == "."):
+            return bazel_version[:i]
+    return bazel_version
 
 # Parse the bazel version string from `native.bazel_version`.
 # e.g.
 # "0.10.0rc1 abc123d" => (0, 10, 0)
 # "0.3.0" => (0, 3, 0)
 def _parse_bazel_version(bazel_version):
-  """Parses a version string into a 3-tuple of ints
+    """Parses a version string into a 3-tuple of ints
 
-  int tuples can be compared directly using binary operators (<, >).
+    int tuples can be compared directly using binary operators (<, >).
 
-  Args:
-    bazel_version: the Bazel version string
+    Args:
+      bazel_version: the Bazel version string
 
-  Returns:
-    An int 3-tuple of a (major, minor, patch) version.
-  """
+    Returns:
+      An int 3-tuple of a (major, minor, patch) version.
+    """
 
-  version = _extract_version_number(bazel_version)
-  return tuple([int(n) for n in version.split(".")])
-
+    version = _extract_version_number(bazel_version)
+    return tuple([int(n) for n in version.split(".")])
 
 def _is_at_most(threshold, version):
-  """Check that a version is lower or equals to a threshold.
+    """Check that a version is lower or equals to a threshold.
 
-  Args:
-    threshold: the maximum version string
-    version: the version string to be compared to the threshold
+    Args:
+      threshold: the maximum version string
+      version: the version string to be compared to the threshold
 
-  Returns:
-    True if version <= threshold.
-  """
-  return _parse_bazel_version(version) <= _parse_bazel_version(threshold)
-
+    Returns:
+      True if version <= threshold.
+    """
+    return _parse_bazel_version(version) <= _parse_bazel_version(threshold)
 
 def _is_at_least(threshold, version):
-  """Check that a version is higher or equals to a threshold.
+    """Check that a version is higher or equals to a threshold.
 
-  Args:
-    threshold: the minimum version string
-    version: the version string to be compared to the threshold
+    Args:
+      threshold: the minimum version string
+      version: the version string to be compared to the threshold
 
-  Returns:
-    True if version >= threshold.
-  """
+    Returns:
+      True if version >= threshold.
+    """
 
-  return _parse_bazel_version(version) >= _parse_bazel_version(threshold)
+    return _parse_bazel_version(version) >= _parse_bazel_version(threshold)
 
+def _check_bazel_version(minimum_bazel_version, maximum_bazel_version = None, bazel_version = None):
+    """Check that the version of Bazel is valid within the specified range.
 
-def _check_bazel_version(minimum_bazel_version, maximum_bazel_version=None, bazel_version=None):
-  """Check that the version of Bazel is valid within the specified range.
+    Args:
+      minimum_bazel_version: minimum version of Bazel expected
+      maximum_bazel_version: maximum version of Bazel expected
+      bazel_version: the version of Bazel to check. Used for testing, defaults to native.bazel_version
+    """
+    if not bazel_version:
+        if "bazel_version" not in dir(native):
+            fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % minimum_bazel_version)
+        elif not native.bazel_version:
+            print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
+            print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
+            return
+        else:
+            bazel_version = native.bazel_version
 
-  Args:
-    minimum_bazel_version: minimum version of Bazel expected
-    maximum_bazel_version: maximum version of Bazel expected
-    bazel_version: the version of Bazel to check. Used for testing, defaults to native.bazel_version
-  """
-  if not bazel_version:
-    if "bazel_version" not in dir(native):
-      fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % minimum_bazel_version)
-    elif not native.bazel_version:
-      print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
-      print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
-      return
-    else:
-      bazel_version = native.bazel_version
+    if not _is_at_least(
+        threshold = minimum_bazel_version,
+        version = bazel_version,
+    ):
+        fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
+            bazel_version,
+            minimum_bazel_version,
+        ))
 
-  if not _is_at_least(
-      threshold = minimum_bazel_version,
-      version = bazel_version):
-    fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
-        bazel_version, minimum_bazel_version))
+    if maximum_bazel_version:
+        max_bazel_version = _parse_bazel_version(maximum_bazel_version)
+        if not _is_at_most(
+            threshold = maximum_bazel_version,
+            version = bazel_version,
+        ):
+            fail("\nCurrent Bazel version is {}, expected at most {}\n".format(
+                bazel_version,
+                maximum_bazel_version,
+            ))
 
-  if maximum_bazel_version:
-    max_bazel_version = _parse_bazel_version(maximum_bazel_version)
-    if not _is_at_most(
-        threshold = maximum_bazel_version,
-        version = bazel_version):
-      fail("\nCurrent Bazel version is {}, expected at most {}\n".format(
-          bazel_version, maximum_bazel_version))
-
-  pass
+    pass
 
 versions = struct(
-    get=_get_bazel_version,
-    parse=_parse_bazel_version,
-    check=_check_bazel_version,
-    is_at_most=_is_at_most,
-    is_at_least=_is_at_least,
+    get = _get_bazel_version,
+    parse = _parse_bazel_version,
+    check = _check_bazel_version,
+    is_at_most = _is_at_most,
+    is_at_least = _is_at_least,
 )

--- a/dotnet/toolchain/toolchains.bzl
+++ b/dotnet/toolchain/toolchains.bzl
@@ -2,7 +2,6 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:dotnet_toolchain.bzl",
     "dotnet_toolchain",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/private:core_toolchain.bzl",
     "core_toolchain",
@@ -29,174 +28,179 @@ load(
     "@io_bazel_rules_dotnet//dotnet/private:sdk_net.bzl",
     "net_download_sdk",
 )
-
 load(
     "@io_bazel_rules_dotnet//dotnet/platform:list.bzl",
     "DOTNETARCH",
-    "DOTNETOS",
     "DOTNETIMPL",
     "DOTNETIMPL_OS_ARCH",
+    "DOTNETOS",
 )
 
 DEFAULT_VERSION = "4.2.3"
 CORE_DEFAULT_VERSION = "2.1.200"
 NET_ROSLYN_DEFAULT_VERSION = "2.8.2"
-NET_DEFAULT_VERSION="4.7.2"
+NET_DEFAULT_VERSION = "4.7.2"
 
 SDK_REPOSITORIES = {
     "4.2.3": {
-        "mono_darwin_amd64":      ("http://bazel-mirror.storage.googleapis.com/download.mono-project.com/archive/4.2.3/macos-10-x86/MonoFramework-MDK-4.2.3.4.macos10.xamarin.x86.tar.gz", 
-                                "a7afb92d4a81f17664a040c8f36147e57a46bb3c33314b73ec737ad73608e08b"),
+        "mono_darwin_amd64": (
+            "http://bazel-mirror.storage.googleapis.com/download.mono-project.com/archive/4.2.3/macos-10-x86/MonoFramework-MDK-4.2.3.4.macos10.xamarin.x86.tar.gz",
+            "a7afb92d4a81f17664a040c8f36147e57a46bb3c33314b73ec737ad73608e08b",
+        ),
     },
 }
 
 CORE_SDK_REPOSITORIES = {
     "2.1.200": {
-        "core_windows_amd64":      ("https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.zip", 
-                                "f3c92c52d88364ac4359716e11e13b67f0e4ea256676b56334a4eb88c728e7fd"),
-        "core_linux_amd64":      ("https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-linux-x64.tar.gz", 
-                                "58977b4b232f5fe97f9825340ce473cf1ec1bad76eb512fe6b5e2210c76c09de"),
-        "core_darwin_amd64":      ("https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.tar.gz", 
-                                "ac695c3319caf043e6b40861906cd4d396ba8922fd206332d2a778635667a2ba"),
+        "core_windows_amd64": (
+            "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-win-x64.zip",
+            "f3c92c52d88364ac4359716e11e13b67f0e4ea256676b56334a4eb88c728e7fd",
+        ),
+        "core_linux_amd64": (
+            "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-linux-x64.tar.gz",
+            "58977b4b232f5fe97f9825340ce473cf1ec1bad76eb512fe6b5e2210c76c09de",
+        ),
+        "core_darwin_amd64": (
+            "https://download.microsoft.com/download/3/7/1/37189942-C91D-46E9-907B-CF2B2DE584C7/dotnet-sdk-2.1.200-osx-x64.tar.gz",
+            "ac695c3319caf043e6b40861906cd4d396ba8922fd206332d2a778635667a2ba",
+        ),
     },
 }
 
 NET_ROSLYN_REPOSITORIES = {
     "2.8.2": {
-        "net_windows_amd64":      ("https://www.nuget.org/api/v2/package/Microsoft.Net.Compilers/2.8.2/", 
-                                "48d0d13d8667e16ce150fbb7d804d12d9b9bca8bba9003eaccf1f105cbd427f6"),
+        "net_windows_amd64": (
+            "https://www.nuget.org/api/v2/package/Microsoft.Net.Compilers/2.8.2/",
+            "48d0d13d8667e16ce150fbb7d804d12d9b9bca8bba9003eaccf1f105cbd427f6",
+        ),
     },
 }
 
-
 def _generate_toolchains():
-  # Use all the above information to generate all the possible toolchains we might support
-  toolchains = []
-  for impl, os, arch in DOTNETIMPL_OS_ARCH:
-    host = "{}_{}_{}".format(impl, os, arch)
-    toolchain_name = "dotnet_{}".format(host)
-    csc_flags = []
-    toolchains.append(dict(
-        name = toolchain_name,
-        impl = impl,
-        host = host,
-        csc_flags = csc_flags,
-    ))
-  return toolchains
+    # Use all the above information to generate all the possible toolchains we might support
+    toolchains = []
+    for impl, os, arch in DOTNETIMPL_OS_ARCH:
+        host = "{}_{}_{}".format(impl, os, arch)
+        toolchain_name = "dotnet_{}".format(host)
+        csc_flags = []
+        toolchains.append(dict(
+            name = toolchain_name,
+            impl = impl,
+            host = host,
+            csc_flags = csc_flags,
+        ))
+    return toolchains
 
 _toolchains = _generate_toolchains()
 
-
 _label_prefix = "@io_bazel_rules_dotnet//dotnet/toolchain:"
 
-def dotnet_register_toolchains(dotnet_version=DEFAULT_VERSION, core_version=CORE_DEFAULT_VERSION, net_version=NET_DEFAULT_VERSION, net_roslyn_version=NET_ROSLYN_DEFAULT_VERSION):
-  """See /dotnet/toolchains.rst#dostnet-register-toolchains for full documentation."""
-  if "dotnet_download_sdk" not in native.existing_rules() and "dotnet_host_sdk" not in native.existing_rules() and "dotnet_local_sdk" not in native.existing_rules():
-    if dotnet_version in SDK_REPOSITORIES:
-      dotnet_download_sdk(
-          name = "dotnet_sdk",
-          sdks = SDK_REPOSITORIES[dotnet_version],
-      )
-    elif dotnet_version == "host":
-      dotnet_host_sdk(
-          name = "dotnet_sdk"
-      )
-    elif dotnet_version != None:
-      fail("Unknown dotnet version {}".format(dotnet_version))
+def dotnet_register_toolchains(dotnet_version = DEFAULT_VERSION, core_version = CORE_DEFAULT_VERSION, net_version = NET_DEFAULT_VERSION, net_roslyn_version = NET_ROSLYN_DEFAULT_VERSION):
+    """See /dotnet/toolchains.rst#dostnet-register-toolchains for full documentation."""
+    if "dotnet_download_sdk" not in native.existing_rules() and "dotnet_host_sdk" not in native.existing_rules() and "dotnet_local_sdk" not in native.existing_rules():
+        if dotnet_version in SDK_REPOSITORIES:
+            dotnet_download_sdk(
+                name = "dotnet_sdk",
+                sdks = SDK_REPOSITORIES[dotnet_version],
+            )
+        elif dotnet_version == "host":
+            dotnet_host_sdk(
+                name = "dotnet_sdk",
+            )
+        elif dotnet_version != None:
+            fail("Unknown dotnet version {}".format(dotnet_version))
 
-  if "core_download_sdk" not in native.existing_rules():
-    if core_version in CORE_SDK_REPOSITORIES:
-      core_download_sdk(
-          name = "core_sdk",
-          version = core_version,
-          sdks = CORE_SDK_REPOSITORIES[core_version],
-      )
-    elif core_version != None:
-      fail("Unknown core version {}".format(core_version))
+    if "core_download_sdk" not in native.existing_rules():
+        if core_version in CORE_SDK_REPOSITORIES:
+            core_download_sdk(
+                name = "core_sdk",
+                version = core_version,
+                sdks = CORE_SDK_REPOSITORIES[core_version],
+            )
+        elif core_version != None:
+            fail("Unknown core version {}".format(core_version))
 
-  if "net_download_sdk" not in native.existing_rules():
-    if net_roslyn_version in NET_ROSLYN_REPOSITORIES:
-      net_download_sdk(
-          name = "net_sdk",
-          version = net_version,
-          sdks = NET_ROSLYN_REPOSITORIES[net_roslyn_version],
-      )
-    elif net_roslyn_version != None:
-      fail("Unknown .net Roslyn version {}".format(net_roslyn_version))
+    if "net_download_sdk" not in native.existing_rules():
+        if net_roslyn_version in NET_ROSLYN_REPOSITORIES:
+            net_download_sdk(
+                name = "net_sdk",
+                version = net_version,
+                sdks = NET_ROSLYN_REPOSITORIES[net_roslyn_version],
+            )
+        elif net_roslyn_version != None:
+            fail("Unknown .net Roslyn version {}".format(net_roslyn_version))
 
-  # Use the final dictionaries to register all the toolchains
-  for toolchain in _toolchains:
-    name = _label_prefix + toolchain["name"]
-    native.register_toolchains(name)
-
+    # Use the final dictionaries to register all the toolchains
+    for toolchain in _toolchains:
+        name = _label_prefix + toolchain["name"]
+        native.register_toolchains(name)
 
 def declare_constraints():
-  for os, constraint in DOTNETOS.items():
-    if constraint:
-      native.alias(
-          name = os,
-          actual = constraint,
-      )
-    else:
-      native.constraint_value(
-          name = os,
-          constraint_setting = "@bazel_tools//platforms:os",
-      )
-  for arch, constraint in DOTNETARCH.items():
-    if constraint:
-      native.alias(
-          name = arch,
-          actual = constraint,
-      )
-    else:
-      native.constraint_value(
-          name = arch,
-          constraint_setting = "@bazel_tools//platforms:cpu",
-      )
-  native.constraint_setting(name = "dotnetimpl")
-  for impl, constraint in DOTNETIMPL.items():
-      native.constraint_value(
-          name = impl,
-          constraint_setting = ":dotnetimpl",
-      )
-
-
-  for impl, os, arch in DOTNETIMPL_OS_ARCH:
-    native.platform(
-        name = impl + "_" + os + "_" + arch,
-        constraint_values = [
-            ":" + impl,
-            ":" + os,
-            ":" + arch,
-        ],
-    )
-def declare_toolchains():
-  # Use the final dictionaries to create all the toolchains
-  for toolchain in _toolchains:
-    if toolchain["impl"] == "mono":
-        dotnet_toolchain(
-            # Required fields
-            name = toolchain["name"],
-            host = toolchain["host"],
-        )
-    elif toolchain["impl"] == "core":
-        core_toolchain(
-            # Required fields
-            name = toolchain["name"],
-            host = toolchain["host"],
-        )
-    elif toolchain["impl"] == "net":
-        if toolchain["name"] == "dotnet_net_windows_amd64":
-            net_toolchain(
-                # Required fields
-                name = toolchain["name"],
-                host = toolchain["host"],
+    for os, constraint in DOTNETOS.items():
+        if constraint:
+            native.alias(
+                name = os,
+                actual = constraint,
             )
         else:
-            # Hardcoded empty rules for .NET on Linux and ocx
-            net_empty_toolchain(
+            native.constraint_value(
+                name = os,
+                constraint_setting = "@bazel_tools//platforms:os",
+            )
+    for arch, constraint in DOTNETARCH.items():
+        if constraint:
+            native.alias(
+                name = arch,
+                actual = constraint,
+            )
+        else:
+            native.constraint_value(
+                name = arch,
+                constraint_setting = "@bazel_tools//platforms:cpu",
+            )
+    native.constraint_setting(name = "dotnetimpl")
+    for impl, constraint in DOTNETIMPL.items():
+        native.constraint_value(
+            name = impl,
+            constraint_setting = ":dotnetimpl",
+        )
+
+    for impl, os, arch in DOTNETIMPL_OS_ARCH:
+        native.platform(
+            name = impl + "_" + os + "_" + arch,
+            constraint_values = [
+                ":" + impl,
+                ":" + os,
+                ":" + arch,
+            ],
+        )
+
+def declare_toolchains():
+    # Use the final dictionaries to create all the toolchains
+    for toolchain in _toolchains:
+        if toolchain["impl"] == "mono":
+            dotnet_toolchain(
                 # Required fields
                 name = toolchain["name"],
                 host = toolchain["host"],
             )
-  
+        elif toolchain["impl"] == "core":
+            core_toolchain(
+                # Required fields
+                name = toolchain["name"],
+                host = toolchain["host"],
+            )
+        elif toolchain["impl"] == "net":
+            if toolchain["name"] == "dotnet_net_windows_amd64":
+                net_toolchain(
+                    # Required fields
+                    name = toolchain["name"],
+                    host = toolchain["host"],
+                )
+            else:
+                # Hardcoded empty rules for .NET on Linux and ocx
+                net_empty_toolchain(
+                    # Required fields
+                    name = toolchain["name"],
+                    host = toolchain["host"],
+                )


### PR DESCRIPTION
Buildifier is available here:
  https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md

Why use it? To get all files formatted consistently.
More importantly, Buildifier can automatically fix issues in the file
(e.g. migrate code which uses deprecated Bazel features).

Progress towards #84