### PR TITLE
Add nuget2bazel --skipSha256 option

### DIFF
--- a/tools/nuget2bazel/AddCommand.cs
+++ b/tools/nuget2bazel/AddCommand.cs
@@ -19,7 +19,7 @@ namespace nuget2bazel
 {
     public class AddCommand
     {
-        public async Task Do(string package, string version, string rootPath, string mainFile)
+        public async Task Do(string package, string version, string rootPath, string mainFile, bool skipSha256)
         {
             if (rootPath == null)
                 rootPath = Directory.GetCurrentDirectory();
@@ -36,7 +36,7 @@ namespace nuget2bazel
             var found = await packageMetadataResource.GetMetadataAsync(identity, content, logger, CancellationToken.None);
 
             var settings = Settings.LoadDefaultSettings(rootPath, null, new MachineWideSettings());
-            var project = new ProjectBazel(rootPath, mainFile);
+            var project = new ProjectBazel(rootPath, mainFile, skipSha256);
             var sourceRepositoryProvider = new SourceRepositoryProvider(settings, providers);
             var packageManager = new NuGetPackageManager(sourceRepositoryProvider, settings, rootPath)
             {

--- a/tools/nuget2bazel/AddVerb.cs
+++ b/tools/nuget2bazel/AddVerb.cs
@@ -30,5 +30,9 @@ namespace nuget2bazel
             Default = null,
             HelpText = "Basename of the main file in the libs or tools folder if multiple are present")]
         public string MainFile { get; set; }
+
+        [Option('s', "skipSha256",
+            HelpText = "If true, do not emit the sha256 value for generated nuget_package rules")]
+        public bool SkipSha256 { get; set; }
     }
 }

--- a/tools/nuget2bazel/DeleteCommand.cs
+++ b/tools/nuget2bazel/DeleteCommand.cs
@@ -28,7 +28,7 @@ namespace nuget2bazel
             providers.AddRange(Repository.Provider.GetCoreV3());  // Add v3 API support
 
             var settings = Settings.LoadDefaultSettings(rootPath, null, new MachineWideSettings());
-            var project = new ProjectBazel(rootPath, null);
+            var project = new ProjectBazel(rootPath, null, false);
             var sourceRepositoryProvider = new SourceRepositoryProvider(settings, providers);
             var solutionManager = new BazelSolutionManager(project, rootPath);
             var deleteManager = new DeleteOnRestart();

--- a/tools/nuget2bazel/Program.cs
+++ b/tools/nuget2bazel/Program.cs
@@ -13,7 +13,7 @@ namespace nuget2bazel
             var result = parsed.MapResult<AddVerb, DeleteVerb, int>(
                 (AddVerb opts) =>
                 {
-                    var res = new AddCommand().Do(opts.Package, opts.Version, opts.RootPath, opts.MainFile);
+                    var res = new AddCommand().Do(opts.Package, opts.Version, opts.RootPath, opts.MainFile, opts.SkipSha256);
                     res.Wait();
                     return 0;
                 },

--- a/tools/nuget2bazel/WorkspaceEntry.cs
+++ b/tools/nuget2bazel/WorkspaceEntry.cs
@@ -95,7 +95,8 @@ namespace nuget2bazel
             sb.Append($"   name = \"{PackageIdentity.Id.ToLower()}\",\n");
             sb.Append($"   package = \"{PackageIdentity.Id.ToLower()}\",\n");
             sb.Append($"   version = \"{PackageIdentity.Version}\",\n");
-            sb.Append($"   sha256 = \"{Sha256}\",\n");
+            if (!String.IsNullOrEmpty(Sha256)) 
+                sb.Append($"   sha256 = \"{Sha256}\",\n");
             if (!String.IsNullOrEmpty(CoreLib))
                 sb.Append($"   core_lib = \"{CoreLib}\",\n");
             if (!String.IsNullOrEmpty(NetLib))


### PR DESCRIPTION
Allows user to opt-out of calculating a sha256 value for generated nuget_package rules.