### PR TITLE
issue #107 add .Net Core v2.1.503

### DIFF
--- a/3rd_party/abstractions.xunit/repo_v2.1.503.bzl
+++ b/3rd_party/abstractions.xunit/repo_v2.1.503.bzl
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "core_binary", "core_library", "core_resource")
+load("@io_bazel_rules_dotnet//3rd_party:abstractions.xunit/repo.bzl", "buildall")
+
+framework = "v2.1.503"
+
+buildall(framework)

--- a/3rd_party/assert.xunit/repo_v2.1.503.bzl
+++ b/3rd_party/assert.xunit/repo_v2.1.503.bzl
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "core_binary", "core_library", "core_resource")
+load("@io_bazel_rules_dotnet//3rd_party:assert.xunit/repo.bzl", "buildall")
+
+framework = "v2.1.503"
+
+buildall(framework)

--- a/3rd_party/testfx/repo_v2.1.503.bzl
+++ b/3rd_party/testfx/repo_v2.1.503.bzl
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "core_binary", "core_library", "core_resource")
+load("@io_bazel_rules_dotnet//3rd_party:testfx/repo.bzl", "buildall")
+
+framework = "v2.1.503"
+
+buildall(framework)

--- a/3rd_party/xunit/repo_v2.1.503.bzl
+++ b/3rd_party/xunit/repo_v2.1.503.bzl
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_dotnet//dotnet:defs.bzl", "core_binary", "core_library", "core_resource")
+load("@io_bazel_rules_dotnet//3rd_party:xunit/repo.bzl", "buildall")
+
+framework = "v2.1.503"
+
+buildall(framework)

--- a/dotnet/platform/list.bzl
+++ b/dotnet/platform/list.bzl
@@ -58,6 +58,7 @@ DOTNET_NET_FRAMEWORKS = {
 DOTNET_CORE_FRAMEWORKS = {
     "v2.1.200": (".NETCore,Version=v2.1", "NETCOREAPP2_1", "netcoreapp2.1"),
     "v2.1.502": (".NETCore,Version=v2.1", "NETCOREAPP2_1", "netcoreapp2.1"),
+    "v2.1.503": (".NETCore,Version=v2.1", "NETCOREAPP2_1", "netcoreapp2.1"),
     "v2.2.101": (".NETCore,Version=v2.2", "NETCOREAPP2_2", "netcoreapp2.2"),
 }
 

--- a/dotnet/stdlib.core/v2.1.503/BUILD.bazel
+++ b/dotnet/stdlib.core/v2.1.503/BUILD.bazel
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_dotnet//dotnet/stdlib.core:macro.bzl", "all_core_stdlib", "all_core_stdlib215")
+load("@io_bazel_rules_dotnet//dotnet/private:rules/stdlib.bzl", "core_stdlib")
+
+framework = "v2.1.503"
+
+# system.memory.dll is not present in netcoreapp 2.1.200
+
+all_core_stdlib(framework)
+
+all_core_stdlib215(framework)

--- a/dotnet/toolchain/toolchains.bzl
+++ b/dotnet/toolchain/toolchains.bzl
@@ -79,6 +79,20 @@ CORE_SDK_REPOSITORIES = {
             "47fbc7cd65aacfd9e1002057ba29f1a567bd6c9923b1ff7aa5dcb4e48c85de95",
         ),
     },
+    "v2.1.503": {
+        "core_windows_amd64": (
+            "https://download.visualstudio.microsoft.com/download/pr/81e18dc2-7747-4b2d-9912-3be0f83050f1/5bc41cb27df3da63378df2d051be4b7f/dotnet-sdk-2.1.503-win-x64.zip",
+            "d81c6fdf758cbb0f433dad32fa2087e5ba09f55590a0e85832a1da414ed8180d",
+        ),
+        "core_linux_amd64": (
+            "https://download.visualstudio.microsoft.com/download/pr/04d83723-8370-4b54-b8b9-55708822fcde/63aab1f4d0be5246e3a92e1eb3063935/dotnet-sdk-2.1.503-linux-x64.tar.gz",
+            "f8bcee4cdc52e6b907f1a94102ec43977e84c62b7a54be6040e906a7b6ee4453",
+        ),
+        "core_darwin_amd64": (
+            "https://download.visualstudio.microsoft.com/download/pr/c922688d-74e8-4af5-bcc8-5850eafbca7f/cf3b9a0b06c0dfa3a5098f893a9730bd/dotnet-sdk-2.1.503-osx-x64.tar.gz",
+            "47fbc7cd65aacfd9e1002057ba29f1a567bd6c9923b1ff7aa5dcb4e48c85de95",
+        ),
+    },
     "v2.2.101": {
         "core_windows_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/25d4104d-1776-41cb-b96e-dff9e9bf1542/b878c013de90f0e6c91f6f3c98a2d592/dotnet-sdk-2.2.101-win-x64.zip",


### PR DESCRIPTION
Download of the .Net Core v2.1.502 failed. Fix it by using the version v2.1.503