### PR TITLE
 Fix the core launcher on Linux

### DIFF
--- a/dotnet/tools/launcher_core/main.c
+++ b/dotnet/tools/launcher_core/main.c
@@ -21,35 +21,50 @@ const char *Exe = NULL;
 
 static void Execute(int argc, char *argv[], const char *manifestDir)
 {
-	char dotnet[64 * 1024], torun[64 * 1024], *p;
-	char **newargv = (char **)malloc((argc + 2) * sizeof(char *));
-	//char *newargv[1024];
-	int i;
-
-	// Locate dotnet runner
-	sprintf(dotnet, "%s/dotnet", manifestDir);
+	char   dotnet[64 * 1024] = {0};
+	char   torun[64 * 1024]  = {0};
+	char  *p                 = NULL;
+	char **newargv           = NULL;
 
 	// Based on current exe calculate _0.dll to run
+	//
+	// Either
+	//     Exe = <some_prefix>/my_exe_name
+	// Or
+	//     Exe = <some_prefix>/my_exe_name.exe
+	//
+	// The path we want to calculate looks like:
+	//     torun = <manifestDir>/my_exe_name_0.dll
 	p = strrchr(Exe, '/');
-	sprintf(torun, "%s/%s", manifestDir, p + 1);
+	sprintf(torun, "%s/%s", manifestDir, p);
+
+	// If torun ends in ".exe", strip it off
 	p = strrchr(torun, '.');
-	if (p == NULL)
-	{
-		printf(". not found in %s\n", torun);
-		exit(-1);
+	if (p != NULL && (strcmp(p, ".exe") == 0)) {
+		*p = '\0';
 	}
-	strcpy(p, "_0.dll");
+
+	// Add the new postfix
+	strcat(torun, "_0.dll");
 
 	// Prepare arguments
+	newargv = calloc(argc + 2, sizeof(char *));
+	if (newargv == NULL) {
+		printf("Failed to allocate memory\n");
+		exit(-1);
+	}
+
+	sprintf(dotnet, "%s/dotnet", manifestDir);
 	newargv[0] = dotnet;
 	newargv[1] = torun;
-	for (i = 1; i < argc; ++i)
+	for (int i = 1; i < argc; ++i) {
 		newargv[i + 1] = argv[i];
-	newargv[i + 1] = NULL;
+	}
+	newargv[argc + 1] = NULL;
 
 	if (IsVerbose())
 	{
-		for (i = 0; i < argc + 2; ++i)
+		for (int i = 0; i < argc + 2; ++i)
 			printf("argv[%d] = %s\n", i, newargv[i]);
 	}
 #ifdef _MSC_VER


### PR DESCRIPTION
Part of the netcore launcher attempted to form the dll filepath by transforming a path of the form `<somePrefix>/exeName.exe` into `<manifestDir>/exeName_0.dll`.

The implementation failed on linux, as the exe name didn't end in ".exe" (it has no file extension). This PR calculates the path to the main dll more correctly.

This PR also fixes a few self-inconsistent code style points in the touched file.