### PR TITLE
Adding support for correctly building .NET Standard assemblies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_dotnet//dotnet/private:context.bzl", "core_context_data", "dotnet_context_data", "net_context_data")
+load("@io_bazel_rules_dotnet//dotnet/private:context.bzl", "core_context_data", "dotnet_context_data", "net_context_data", "netstandard_context_data")
 load("//dotnet:defs.bzl", "DEFAULT_DOTNET_CORE_FRAMEWORK", "DOTNET_CORE_FRAMEWORKS", "DOTNET_NET_FRAMEWORKS")
 
 dotnet_context_data(
@@ -17,6 +17,10 @@ net_context_data(
     name = "net_context_data",
     framework = "net472",
     libVersion = "4.7.2",
+)
+
+netstandard_context_data(
+    name = "netstandard_context_data",
 )
 
 exports_files(["AUTHORS"])

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,7 @@ load(
     "mono_register_sdk",
     "net_gac4",
     "net_register_sdk",
+    "netstandard_register_sdk",
     "nuget_package",
     "vs2017_ref_net",
 )
@@ -41,6 +42,12 @@ core_register_sdk(
 net_register_sdk(
     "net471",
     name = "net_sdk",
+)
+
+# Default netstandard_sdk
+netstandard_register_sdk(
+    "2.0.3",
+    name = "netstandard_sdk",
 )
 
 net_gac4(

--- a/dotnet/BUILD
+++ b/dotnet/BUILD
@@ -20,3 +20,8 @@ toolchain_type(
     name = "toolchain_net",
     visibility = ["//visibility:public"],
 )
+
+toolchain_type(
+    name = "toolchain_netstandard",
+    visibility = ["//visibility:public"],
+)

--- a/dotnet/defs.bzl
+++ b/dotnet/defs.bzl
@@ -4,6 +4,7 @@ load(
     _dotnet_context = "dotnet_context",
     _dotnet_context_data = "dotnet_context_data",
     _net_context_data = "net_context_data",
+    _netstandard_context_data = "netstandard_context_data",
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/toolchain:toolchains.bzl",
@@ -11,6 +12,7 @@ load(
     _dotnet_register_toolchains = "dotnet_register_toolchains",
     _mono_register_sdk = "mono_register_sdk",
     _net_register_sdk = "net_register_sdk",
+    _netstandard_register_sdk = "netstandard_register_sdk",
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/private:dotnet_toolchain.bzl",
@@ -31,6 +33,7 @@ load(
     _core_library = "core_library",
     _dotnet_library = "dotnet_library",
     _net_library = "net_library",
+    _netstandard_library = "netstandard_library",
 )
 load(
     "@io_bazel_rules_dotnet//dotnet/private:rules/resx.bzl",
@@ -94,6 +97,7 @@ dotnet_register_toolchains = _dotnet_register_toolchains
 mono_register_sdk = _mono_register_sdk
 net_register_sdk = _net_register_sdk
 core_register_sdk = _core_register_sdk
+netstandard_register_sdk = _netstandard_register_sdk
 dotnet_toolchain = _dotnet_toolchain
 dotnet_repositories = _dotnet_repositories
 core_binary = _core_binary
@@ -102,6 +106,7 @@ net_binary = _net_binary
 core_library = _core_library
 dotnet_library = _dotnet_library
 net_library = _net_library
+netstandard_library = _netstandard_library
 core_resx = _core_resx
 dotnet_resx = _dotnet_resx
 net_resx = _net_resx
@@ -134,3 +139,4 @@ DEFAULT_DOTNET_CORE_FRAMEWORK = _DEFAULT_DOTNET_CORE_FRAMEWORK
 core_context_data = _core_context_data
 dotnet_context_data = _dotnet_context_data
 net_context_data = _net_context_data
+netstandard_context_data = _netstandard_context_data

--- a/dotnet/platform/list.bzl
+++ b/dotnet/platform/list.bzl
@@ -2,6 +2,7 @@ DOTNETIMPL = {
     "mono": None,
     "core": None,
     "net": None,
+    "netstandard": None,
 }
 
 DOTNETOS = {
@@ -24,6 +25,9 @@ DOTNETIMPL_OS_ARCH = (
     ("net", "windows", "amd64"),
     ("net", "linux", "amd64"),
     ("net", "darwin", "amd64"),
+    ("netstandard", "windows", "amd64"),
+    ("netstandard", "linux", "amd64"),
+    ("netstandard", "darwin", "amd64"),
 )
 
 # struct:

--- a/dotnet/private/actions/assembly_netstandard.bzl
+++ b/dotnet/private/actions/assembly_netstandard.bzl
@@ -1,0 +1,163 @@
+load(
+    "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
+    "as_iterable",
+)
+load(
+    "@io_bazel_rules_dotnet//dotnet/private:skylib/lib/paths.bzl",
+    "paths",
+)
+load(
+    "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
+    "DotnetLibrary",
+    "DotnetResource",
+    "DotnetResourceList",
+)
+
+def _map_dep(deps):
+    return deps[DotnetLibrary].result.path
+
+def _map_resource(d):
+    return d.result.path + "," + d.identifier
+
+def _make_runner_arglist(dotnet, deps, resources, output, pdb, executable, defines, unsafe, keyfile):
+    args = dotnet.actions.args()
+
+    # /out:<file>
+    args.add(output.path, format = "/out:%s")
+
+    if executable:
+        target = "exe"
+    else:
+        target = "library"
+
+    # /target (exe for binary, library for lib, module for module)
+    args.add(target, format = "/target:%s")
+
+    args.add("/fullpaths")
+    args.add("/nostdlib")
+    args.add("/langversion:latest")
+    args.add("/nologo")
+
+    if pdb:
+        args.add("-debug:full")
+        args.add("-pdb:" + pdb.path)
+
+    # /warn
+    #args.add(format="/warn:%s", value=str(ctx.attr.warn))
+
+    # /modulename:<string> only used for modules
+    #libdirs = _get_libdirs(depinfo.dlls)
+    #libdirs = _get_libdirs(depinfo.transitive_dlls, libdirs)
+
+    # /lib:dir1,[dir1]
+    #if libdirs:
+    #  args.add(format="/lib:%s", value=libdirs)
+
+    if deps and len(deps) > 0:
+        args.add_all(deps, format_each = "/reference:%s", map_each = _map_dep)
+
+    args.add(dotnet.stdlib, format = "/reference:%s")
+
+    if defines and len(defines) > 0:
+        args.add_all(defines, format_each = "/define:%s")
+
+    if unsafe:
+        args.add("/unsafe")
+
+    if keyfile:
+        args.add("-keyfile:" + keyfile.files.to_list()[0].path)
+
+    # /debug
+    #debug = ctx.var.get("BINMODE", "") == "-dbg"
+    #if debug:
+    #  args.add("/debug")
+
+    # /warnaserror
+    # TODO(jeremy): /define:name[;name2]
+
+    for r in resources:
+        if r[DotnetResourceList].result and len(r[DotnetResourceList].result) > 0:
+            args.add_all(r[DotnetResourceList].result, format_each = "/resource:%s", map_each = _map_resource)
+
+    # TODO(jeremy): /resource:filename[,identifier[,accesibility-modifier]]
+
+    # /main:class
+    #if hasattr(ctx.attr, "main_class") and ctx.attr.main_class:
+    #  args.add(format="/main:%s", value=ctx.attr.main_class)
+
+    #args.add(format="/resource:%s", value=ctx.files.resources)
+
+    # TODO(jwall): /parallel
+
+    return args
+
+def emit_assembly_netstandard(
+        dotnet,
+        name,
+        srcs,
+        deps = None,
+        out = None,
+        resources = None,
+        executable = True,
+        defines = None,
+        unsafe = False,
+        data = None,
+        keyfile = None):
+    """See dotnet/toolchains.rst#binary for full documentation."""
+
+    if name == "" and out == None:
+        fail("either name or out must be set")
+
+    if not out:
+        result = dotnet.declare_file(dotnet, path = name)
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
+
+    if dotnet.debug:
+        pdb = dotnet.declare_file(dotnet, path = paths.split_extension(name)[0] + ".pdb")
+    else:
+        pdb = None
+
+    deps_libraries = [d[DotnetLibrary] for d in deps]
+    transitive = depset(direct = deps, transitive = [d[DotnetLibrary].transitive for d in deps])
+
+    runner_args = _make_runner_arglist(dotnet, transitive.to_list(), resources, result, pdb, executable, defines, unsafe, keyfile)
+
+    attr_srcs = [f for t in srcs for f in as_iterable(t.files)]
+    runner_args.add_all(attr_srcs)
+
+    attr_extra_srcs = [f for t in dotnet.extra_srcs for f in as_iterable(t.files)]
+    runner_args.add_all(attr_extra_srcs)
+
+    runner_args.set_param_file_format("multiline")
+
+    paramfilepath = name + ".param"
+    paramfile = dotnet.declare_file(dotnet, path = paramfilepath)
+
+    dotnet.actions.write(output = paramfile, content = runner_args)
+
+    deps_files = [d[DotnetLibrary].result for d in deps]
+    dotnet.actions.run(
+        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
+        outputs = [result] + ([pdb] if pdb else []),
+        executable = dotnet.runner,
+        arguments = [dotnet.mcs.path, "/noconfig", "@" + paramfile.path],
+        mnemonic = "DotNetStandardCompile",
+        progress_message = (
+            "Compiling " + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
+
+    extra = depset(direct = [result] + [dotnet.stdlib] + ([pdb] if pdb else []), transitive = [t.files for t in data] if data else [])
+    direct = extra.to_list()
+    runfiles = depset(direct = direct, transitive = [a[DotnetLibrary].runfiles for a in deps])
+
+    return dotnet.new_library(
+        dotnet = dotnet,
+        name = name,
+        deps = deps,
+        transitive = transitive,
+        result = result,
+        pdb = pdb,
+        runfiles = runfiles,
+    )

--- a/dotnet/private/actions/resx_netstandard.bzl
+++ b/dotnet/private/actions/resx_netstandard.bzl
@@ -1,0 +1,62 @@
+load(
+    "@io_bazel_rules_dotnet//dotnet/private:common.bzl",
+    "as_iterable",
+)
+load(
+    "@io_bazel_rules_dotnet//dotnet/private:providers.bzl",
+    "DotnetLibrary",
+)
+
+def _make_runner_arglist(dotnet, source, output, resgen):
+    args = dotnet.actions.args()
+
+    if type(source) == "Target":
+        args.add_all(source.files)
+    else:
+        args.add(source)
+    args.add(output)
+
+    return args
+
+def emit_resx_netstandard(
+        dotnet,
+        name = "",
+        src = None,
+        identifier = None,
+        out = None,
+        customresgen = None):
+    if name == "" and out == None:
+        fail("either name or out must be set")
+
+    if not out:
+        result = dotnet.declare_file(dotnet, path = name + ".resources")
+    else:
+        result = dotnet.declare_file(dotnet, path = out)
+
+    args = _make_runner_arglist(dotnet, src, result, customresgen.files_to_run.executable.path)
+
+    # We use the command to extrace shell path and force runfiles creation
+    resolve = dotnet._ctx.resolve_tools(tools = [customresgen])
+
+    inputs = src.files.to_list() if type(src) == "Target" else [src]
+
+    dotnet.actions.run(
+        inputs = inputs + resolve[0].to_list(),
+        tools = customresgen.files,
+        outputs = [result],
+        executable = customresgen.files_to_run.executable,
+        arguments = [args],
+        env = {"RUNFILES_MANIFEST_FILE": customresgen.files_to_run.runfiles_manifest.path},
+        mnemonic = "DotNetStandardResxCompile",
+        input_manifests = resolve[1],
+        progress_message = (
+            "Compiling resoources" + dotnet.label.package + ":" + dotnet.label.name
+        ),
+    )
+
+    return dotnet.new_resource(
+        dotnet = dotnet,
+        name = name,
+        result = result,
+        identifier = identifier,
+    )

--- a/dotnet/private/context.bzl
+++ b/dotnet/private/context.bzl
@@ -186,6 +186,49 @@ core_context_data = rule(
     },
 )
 
+netstandard_context_data = rule(
+    _dotnet_context_data,
+    attrs = {
+        "mcs_bin": attr.label(
+            allow_files = True,
+            default = "@netstandard_sdk//:mcs_bin",
+        ),
+        "mono_bin": attr.label(
+            allow_files = True,
+            default = "@netstandard_sdk//:mono_bin",
+        ),
+        "lib": attr.label(
+            allow_files = True,
+            default = "@netstandard_sdk//:lib",
+        ),
+        "tools": attr.label(
+            allow_files = True,
+            default = "@netstandard_sdk//:lib",
+        ),
+        "shared": attr.label(
+            allow_files = True,
+            default = "@netstandard_sdk//:shared",
+        ),
+        "host": attr.label(
+            allow_files = True,
+            default = "@netstandard_sdk//:host",
+        ),
+        "libVersion": attr.string(
+            default = "",
+        ),
+        "framework": attr.string(
+            default = "",
+        ),
+        "_toolchain_type": attr.string(
+            default = "@io_bazel_rules_dotnet//dotnet:toolchain_netstandard",
+        ),
+        "extra_srcs": attr.label_list(
+            allow_files = True,
+            default = [],
+        ),
+    },
+)
+
 net_context_data = rule(
     _dotnet_context_data,
     attrs = {

--- a/dotnet/private/netstandard_toolchain.bzl
+++ b/dotnet/private/netstandard_toolchain.bzl
@@ -1,0 +1,134 @@
+# Copyright 2016 The Bazel Go Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Toolchain rules used by dotnet.
+"""
+
+load(
+    "@io_bazel_rules_dotnet//dotnet/private:skylib/lib/paths.bzl",
+    "paths",
+)
+load("@io_bazel_rules_dotnet//dotnet/private:actions/assembly_netstandard.bzl", "emit_assembly_netstandard")
+load("@io_bazel_rules_dotnet//dotnet/private:actions/resx_netstandard.bzl", "emit_resx_netstandard")
+
+def _get_dotnet_runner(context_data, ext):
+    for f in context_data._mono_bin.files.to_list():
+        basename = paths.basename(f.path)
+        if basename != "dotnet" + ext:
+            continue
+        return f
+    fail("Could not find dotnet core executable in netstandard_sdk (mono_bin)")
+
+def _get_dotnet_mcs(context_data):
+    for f in context_data._mcs_bin.files.to_list():
+        basename = paths.basename(f.path)
+        if basename != "csc.dll":
+            continue
+        return f
+
+    for f in context_data._lib.files.to_list():
+        basename = paths.basename(f.path)
+        if basename != "csc.dll":
+            continue
+        return f
+    fail("Could not find csc.dll in netstandard_sdk (mcs_bin, lib)")
+
+def _get_dotnet_resgen(context_data):
+    return None
+
+def _get_dotnet_tlbimp(context_data):
+    return None
+
+def _get_dotnet_stdlib(context_data):
+    for f in context_data._shared.files.to_list():
+        basename = paths.basename(f.path)
+        #if basename != "netstandard.dll":
+        if basename != "mscorlib.dll":
+            continue
+        return f
+    fail("Could not find netstandard in netstandard_sdk (lib, %s)" % context_data._shared)
+
+def _get_dotnet_stdlib_byname(shared, lib, libVersion, name):
+    lname = name.lower()
+    for f in shared.files.to_list():
+        basename = paths.basename(f.path)
+        if basename.lower() != lname:
+            continue
+        return f
+
+    for f in lib.files.to_list():
+        basename = paths.basename(f.path)
+        if basename.lower() != lname:
+            continue
+        return f
+    fail("Could not find %s in netstandard_sdk (shared, lib)" % name)
+
+def _netstandard_toolchain_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        name = ctx.label.name,
+        default_dotnetimpl = ctx.attr.dotnetimpl,
+        default_dotnetos = ctx.attr.dotnetos,
+        default_dotnetarch = ctx.attr.dotnetarch,
+        get_dotnet_runner = _get_dotnet_runner,
+        get_dotnet_mcs = _get_dotnet_mcs,
+        get_dotnet_resgen = _get_dotnet_resgen,
+        get_dotnet_tlbimp = _get_dotnet_tlbimp,
+        get_dotnet_stdlib = _get_dotnet_stdlib,
+        actions = struct(
+            assembly = emit_assembly_netstandard,
+            resx = emit_resx_netstandard,
+            com_ref = None,
+            stdlib_byname = _get_dotnet_stdlib_byname,
+        ),
+        flags = struct(
+            compile = (),
+        ),
+    )]
+
+_netstandard_toolchain = rule(
+    _netstandard_toolchain_impl,
+    attrs = {
+        # Minimum requirements to specify a toolchain
+        "dotnetimpl": attr.string(mandatory = True),
+        "dotnetos": attr.string(mandatory = True),
+        "dotnetarch": attr.string(mandatory = True),
+    },
+)
+
+def netstandard_toolchain(name, host, constraints = [], **kwargs):
+    """See dotnet/toolchains.rst#core-toolchain for full documentation."""
+
+    elems = host.split("_")
+    impl, os, arch = elems[0], elems[1], elems[2]
+    host_constraints = constraints + [
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + os,
+        "@io_bazel_rules_dotnet//dotnet/toolchain:" + arch,
+    ]
+
+    impl_name = name + "-impl"
+    _netstandard_toolchain(
+        name = impl_name,
+        dotnetimpl = impl,
+        dotnetos = os,
+        dotnetarch = arch,
+        tags = ["manual"],
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
+    native.toolchain(
+        name = name,
+        toolchain_type = "@io_bazel_rules_dotnet//dotnet:toolchain_netstandard",
+        exec_compatible_with = host_constraints,
+        toolchain = ":" + impl_name,
+    )

--- a/dotnet/private/rules/library.bzl
+++ b/dotnet/private/rules/library.bzl
@@ -93,3 +93,20 @@ net_library = rule(
     toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_net"],
     executable = False,
 )
+
+netstandard_library = rule(
+    _library_impl,
+    attrs = {
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "resources": attr.label_list(providers = [DotnetResourceList]),
+        "srcs": attr.label_list(allow_files = [".cs"]),
+        "out": attr.string(),
+        "defines": attr.string_list(),
+        "unsafe": attr.bool(default = False),
+        "data": attr.label_list(allow_files = True),
+        "keyfile": attr.label(allow_files = True),
+        "dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:netstandard_context_data")),
+    },
+    toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_netstandard"],
+    executable = False,
+)

--- a/dotnet/private/rules/stdlib.bzl
+++ b/dotnet/private/rules/stdlib.bzl
@@ -68,6 +68,18 @@ core_stdlib = rule(
     executable = False,
 )
 
+netstandard_stdlib = rule(
+    _stdlib_impl,
+    attrs = {
+        "dll": attr.string(),
+        "deps": attr.label_list(providers = [DotnetLibrary]),
+        "data": attr.label_list(allow_files = True),
+        "dotnet_context_data": attr.label(default = Label("@io_bazel_rules_dotnet//:netstandard_context_data")),
+    },
+    toolchains = ["@io_bazel_rules_dotnet//dotnet:toolchain_netstandard"],
+    executable = False,
+)
+
 net_stdlib = rule(
     _stdlib_impl,
     attrs = {

--- a/dotnet/private/sdk_netstandard.bzl
+++ b/dotnet/private/sdk_netstandard.bzl
@@ -1,0 +1,79 @@
+load("@io_bazel_rules_dotnet//dotnet/private:common.bzl", "bat_extension", "executable_extension")
+
+def _get_shared_dir(ctx):
+    p = ctx.path("netstandard/build/netstandard2.0")
+    content = p.readdir()
+    for c in content:
+        result = c.get_child("netstandard.dll")
+        if result.exists:
+            return c
+
+    fail("netstandard.dll doesn't exist in " + p)
+
+def _netstandard_download_sdk_impl(ctx):
+    if ctx.os.name == "linux":
+        sdk_host = "core_linux_amd64"
+        stdlib_host = "netstandard_linux_amd64"
+    elif ctx.os.name == "mac os x":
+        sdk_host = "core_darwin_amd64"
+        stdlib_host = "netstandard_darwin_amd64"
+    elif ctx.os.name.startswith("windows"):
+        sdk_host = "core_windows_amd64"
+        stdlib_host = "netstandard_windows_amd64"
+    else:
+        fail("Unsupported operating system: " + ctx.os.name)
+    sdks = ctx.attr.sdks
+    if sdk_host not in sdks:
+        fail("Unsupported SDK host {}".format(sdk_host))
+    netstandard = ctx.attr.netstandard
+    if stdlib_host not in netstandard:
+        fail("Unsupported .NET Standard stdlib host {}".format(stdlib_host))
+    filename, sha256 = ctx.attr.sdks[sdk_host]
+    stdlib, stdlib_hash = ctx.attr.netstandard[stdlib_host]
+    _sdk_build_file(ctx)
+    _remote_sdk(ctx, [filename], ctx.attr.strip_prefix, sha256)
+    _remote_stdlib(ctx, [stdlib], ctx.attr.strip_prefix, stdlib_hash)
+    ctx.symlink("core/sdk/" + ctx.attr.version + "/Roslyn/bincore", "mcs_bin")
+    ctx.symlink("core/.", "mono_bin")
+    ctx.symlink("core/sdk/" + ctx.attr.version, "lib")
+    ctx.symlink(_get_shared_dir(ctx), "shared")
+    ctx.symlink("core/host/", "host")
+
+netstandard_download_sdk = repository_rule(
+    _netstandard_download_sdk_impl,
+    attrs = {
+        "sdks": attr.string_list_dict(),
+        "urls": attr.string_list(),
+        "version": attr.string(),
+        "targetFrameworkString": attr.string(),
+        "strip_prefix": attr.string(default = ""),
+        "netstandard": attr.string_list_dict(),
+    },
+)
+
+"""See /dotnet/toolchains.rst#dotnet-sdk for full documentation."""
+
+def _remote_sdk(ctx, urls, strip_prefix, sha256):
+    ctx.download_and_extract(
+        url = urls,
+        stripPrefix = strip_prefix,
+        sha256 = sha256,
+        output = "core",
+    )
+
+def _sdk_build_file(ctx):
+    ctx.file("ROOT")
+    ctx.template(
+        "BUILD.bazel",
+        Label("@io_bazel_rules_dotnet//dotnet/private:BUILD.sdk.bazel"),
+        executable = False,
+    )
+
+def _remote_stdlib(ctx, urls, strip_prefix, sha256):
+    ctx.download_and_extract(
+        url = urls,
+        stripPrefix = strip_prefix,
+        output = "netstandard",
+        sha256 = sha256,
+        type = "zip",
+    )

--- a/dotnet/stdlib.netstandard/BUILD.bazel
+++ b/dotnet/stdlib.netstandard/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_dotnet//dotnet/stdlib.netstandard:macro.bzl", "all_netstandard_stdlib")
+load("@io_bazel_rules_dotnet//dotnet/private:rules/stdlib.bzl", "netstandard_stdlib")
+
+all_netstandard_stdlib(None)

--- a/dotnet/stdlib.netstandard/macro.bzl
+++ b/dotnet/stdlib.netstandard/macro.bzl
@@ -1,0 +1,804 @@
+load("@io_bazel_rules_dotnet//dotnet/private:rules/stdlib.bzl", "netstandard_stdlib")
+
+def all_netstandard_stdlib(framework):
+    if framework:
+        context = "@io_bazel_rules_dotnet//:netstandard_context_data_{}".format(framework)
+    else:
+        context = "@io_bazel_rules_dotnet//:netstandard_context_data"
+
+    netstandard_stdlib(
+        name = "microsoft.win32.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.appcontext.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.collections.concurrent.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.collections.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.collections.nongeneric.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.collections.specialized.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.componentmodel.composition.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.componentmodel.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.componentmodel.eventbasedasync.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.componentmodel.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.componentmodel.typeconverter.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.console.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.core.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.data.common.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.data.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.contracts.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.debug.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.fileversioninfo.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.process.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.stacktrace.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.textwritertracelistener.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.tools.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.tracesource.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.diagnostics.tracing.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.drawing.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.drawing.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.dynamic.runtime.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.globalization.calendars.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.globalization.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.globalization.extensions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.compression.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.compression.filesystem.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.compression.zipfile.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.filesystem.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.filesystem.driveinfo.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.filesystem.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.filesystem.watcher.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.isolatedstorage.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.memorymappedfiles.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.pipes.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.io.unmanagedmemorystream.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.linq.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.linq.expressions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.linq.parallel.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.linq.queryable.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.http.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.nameresolution.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.networkinformation.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.ping.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.requests.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.security.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+
+    netstandard_stdlib(
+	    name = "system.net.sockets.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.webheadercollection.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.websockets.client.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.net.websockets.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.numerics.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.objectmodel.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.reflection.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.reflection.extensions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.reflection.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.resources.reader.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.resources.resourcemanager.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.resources.writer.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.compilerservices.visualc.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.extensions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.handles.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.interopservices.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.interopservices.runtimeinformation.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.numerics.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.serialization.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.serialization.formatters.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.serialization.json.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.serialization.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.runtime.serialization.xml.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.claims.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.cryptography.algorithms.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.cryptography.csp.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.cryptography.encoding.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.cryptography.primitives.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.cryptography.x509certificates.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.principal.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.security.securestring.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.servicemodel.web.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.text.encoding.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.text.encoding.extensions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.text.regularexpressions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.overlapped.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.tasks.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.tasks.parallel.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.thread.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.threadpool.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.threading.timer.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.transactions.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.valuetuple.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.web.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.windows.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.linq.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.readerwriter.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.serialization.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.xdocument.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.xmldocument.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.xmlserializer.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.xpath.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "system.xml.xpath.xdocument.dll",
+        deps = [
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "mscorlib.dll",
+        deps = [
+            ":netstandard.dll",
+        ],
+        dotnet_context_data = context,
+    )
+    netstandard_stdlib(
+        name = "netstandard.dll",
+        deps = [
+            ":microsoft.win32.primitives.dll",
+            ":system.appcontext.dll",
+            ":system.collections.concurrent.dll",
+            ":system.collections.dll",
+            ":system.collections.nongeneric.dll",
+            ":system.collections.specialized.dll",
+            ":system.componentmodel.composition.dll",
+            ":system.componentmodel.dll",
+            ":system.componentmodel.eventbasedasync.dll",
+            ":system.componentmodel.primitives.dll",
+            ":system.componentmodel.typeconverter.dll",
+            ":system.console.dll",
+            ":system.core.dll",
+            ":system.data.common.dll",
+            ":system.data.dll",
+            ":system.diagnostics.contracts.dll",
+            ":system.diagnostics.debug.dll",
+            ":system.diagnostics.fileversioninfo.dll",
+            ":system.diagnostics.process.dll",
+            ":system.diagnostics.stacktrace.dll",
+            ":system.diagnostics.textwritertracelistener.dll",
+            ":system.diagnostics.tools.dll",
+            ":system.diagnostics.tracesource.dll",
+            ":system.diagnostics.tracing.dll",
+            ":system.dll",
+            ":system.drawing.dll",
+            ":system.drawing.primitives.dll",
+            ":system.dynamic.runtime.dll",
+            ":system.globalization.calendars.dll",
+            ":system.globalization.dll",
+            ":system.globalization.extensions.dll",
+            ":system.io.compression.dll",
+            ":system.io.compression.filesystem.dll",
+            ":system.io.compression.zipfile.dll",
+            ":system.io.dll",
+            ":system.io.filesystem.dll",
+            ":system.io.filesystem.driveinfo.dll",
+            ":system.io.filesystem.primitives.dll",
+            ":system.io.filesystem.watcher.dll",
+            ":system.io.isolatedstorage.dll",
+            ":system.io.memorymappedfiles.dll",
+            ":system.io.pipes.dll",
+            ":system.io.unmanagedmemorystream.dll",
+            ":system.linq.dll",
+            ":system.linq.expressions.dll",
+            ":system.linq.parallel.dll",
+            ":system.linq.queryable.dll",
+            ":system.net.dll",
+            ":system.net.http.dll",
+            ":system.net.nameresolution.dll",
+            ":system.net.networkinformation.dll",
+            ":system.net.ping.dll",
+            ":system.net.primitives.dll",
+            ":system.net.requests.dll",
+            ":system.net.security.dll",
+            ":system.net.sockets.dll",
+            ":system.net.webheadercollection.dll",
+            ":system.net.websockets.client.dll",
+            ":system.net.websockets.dll",
+            ":system.numerics.dll",
+            ":system.objectmodel.dll",
+            ":system.reflection.dll",
+            ":system.reflection.extensions.dll",
+            ":system.reflection.primitives.dll",
+            ":system.resources.reader.dll",
+            ":system.resources.resourcemanager.dll",
+            ":system.resources.writer.dll",
+            ":system.runtime.compilerservices.visualc.dll",
+            ":system.runtime.dll",
+            ":system.runtime.extensions.dll",
+            ":system.runtime.handles.dll",
+            ":system.runtime.interopservices.dll",
+            ":system.runtime.interopservices.runtimeinformation.dll",
+            ":system.runtime.numerics.dll",
+            ":system.runtime.serialization.dll",
+            ":system.runtime.serialization.formatters.dll",
+            ":system.runtime.serialization.json.dll",
+            ":system.runtime.serialization.primitives.dll",
+            ":system.runtime.serialization.xml.dll",
+            ":system.security.claims.dll",
+            ":system.security.cryptography.algorithms.dll",
+            ":system.security.cryptography.csp.dll",
+            ":system.security.cryptography.encoding.dll",
+            ":system.security.cryptography.primitives.dll",
+            ":system.security.cryptography.x509certificates.dll",
+            ":system.security.principal.dll",
+            ":system.security.securestring.dll",
+            ":system.servicemodel.web.dll",
+            ":system.text.encoding.dll",
+            ":system.text.encoding.extensions.dll",
+            ":system.text.regularexpressions.dll",
+            ":system.threading.dll",
+            ":system.threading.overlapped.dll",
+            ":system.threading.tasks.dll",
+            ":system.threading.tasks.parallel.dll",
+            ":system.threading.thread.dll",
+            ":system.threading.threadpool.dll",
+            ":system.threading.timer.dll",
+            ":system.transactions.dll",
+            ":system.valuetuple.dll",
+            ":system.web.dll",
+            ":system.windows.dll",
+            ":system.xml.dll",
+            ":system.xml.linq.dll",
+            ":system.xml.readerwriter.dll",
+            ":system.xml.serialization.dll",
+            ":system.xml.xdocument.dll",
+            ":system.xml.xmldocument.dll",
+            ":system.xml.xmlserializer.dll",
+            ":system.xml.xpath.dll",
+            ":system.xml.xpath.xdocument.dll",
+        ],
+        dotnet_context_data = context,
+    )
+
+    native.alias(
+        name = "netstandard.library.dll",
+        actual = ":netstandard.dll",
+    )

--- a/dotnet/toolchain/toolchains.bzl
+++ b/dotnet/toolchain/toolchains.bzl
@@ -11,6 +11,10 @@ load(
     "net_toolchain",
 )
 load(
+    "@io_bazel_rules_dotnet//dotnet/private:netstandard_toolchain.bzl",
+    "netstandard_toolchain",
+)
+load(
     "@io_bazel_rules_dotnet//dotnet/private:net_empty_toolchain.bzl",
     "net_empty_toolchain",
 )
@@ -27,6 +31,10 @@ load(
     "net_download_sdk",
 )
 load(
+    "@io_bazel_rules_dotnet//dotnet/private:sdk_netstandard.bzl",
+    "netstandard_download_sdk",
+)
+load(
     "@io_bazel_rules_dotnet//dotnet/platform:list.bzl",
     "DOTNETARCH",
     "DOTNETIMPL",
@@ -40,6 +48,7 @@ DEFAULT_VERSION = "4.2.3"
 CORE_DEFAULT_VERSION = "v2.1.502"
 NET_ROSLYN_DEFAULT_VERSION = "2.10.0"
 NET_DEFAULT_VERSION = "4.7.2"
+NETSTANDARD_DEFAULT_VERSION = "2.0.3"
 
 SDK_REPOSITORIES = {
     "4.2.3": {
@@ -154,6 +163,65 @@ NET_ROSLYN_REPOSITORIES = {
     },
 }
 
+NETSTANDARD_SDK_REPOSITORIES = {
+    "2.0.0": {
+        "netstandard_windows_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.0",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_linux_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.0",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_darwin_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.0",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+    },
+    "2.0.1": {
+        "netstandard_windows_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.1",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_linux_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.1",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_darwin_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.1",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+    },
+    "2.0.2": {
+        "netstandard_windows_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.2",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_linux_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.2",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_darwin_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.2",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+    },
+    "2.0.3": {
+        "netstandard_windows_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.3",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_linux_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.3",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+        "netstandard_darwin_amd64": (
+            "https://www.nuget.org/api/v2/package/NETStandard.Library/2.0.3",
+            "3eb87644f79bcffb3c0331dbdac3c7837265f2cdf58a7bfd93e431776f77c9ba",
+        ),
+    },
+}
+
 def _generate_toolchains():
     # Use all the above information to generate all the possible toolchains we might support
     toolchains = []
@@ -234,6 +302,11 @@ def declare_toolchains():
                 name = toolchain["name"],
                 host = toolchain["host"],
             )
+        elif toolchain["impl"] == "netstandard":
+            netstandard_toolchain(
+                name = toolchain["name"],
+                host = toolchain["host"],
+            )
         elif toolchain["impl"] == "net":
             if toolchain["name"] == "dotnet_net_windows_amd64":
                 net_toolchain(
@@ -268,6 +341,19 @@ def core_register_sdk(core_version, name = None):
         version = core_version[1:],
         targetFrameworkString = DOTNET_CORE_FRAMEWORKS[core_version][0],
         sdks = CORE_SDK_REPOSITORIES[core_version],
+    )
+
+def netstandard_register_sdk(netstandard_version = NETSTANDARD_DEFAULT_VERSION, core_version = CORE_DEFAULT_VERSION, name = None):
+    if core_version not in CORE_SDK_REPOSITORIES:
+        fail("Unknown core version {}".format(core_version))
+
+    netstandard_download_sdk(
+        name = name if name else "netstandard_sdk_{}".format(netstandard_version),
+        version = core_version[1:],
+        targetFrameworkString = DOTNET_CORE_FRAMEWORKS[core_version][0],
+        #sdks = NETSTANDARD_SDK_REPOSITORIES[netstandard_version],
+        sdks = CORE_SDK_REPOSITORIES[core_version],
+        netstandard = NETSTANDARD_SDK_REPOSITORIES[netstandard_version],
     )
 
 def mono_register_sdk():


### PR DESCRIPTION
This change introduces a new rule type, netstandard_library, and
all of the supporting data structures required to build it (context,
SDK definition, toolchain, etc.). Using the netstandard_library rule,
it should now be possible to correctly build a .NET Standard 2.0
assembly, which can be used, in turn, as a reference in a .NET Core
project.

This commit only supports creating .NET Standard 2.0 or greater
assemblies.

Fixes issue #142 