### PR TITLE
docs: update documentation about file extensions required by rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ _static
 _build
 /packages
 .vs
+node_modules
+package-lock.json
+package.json

--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ Examples
   .. code:: python
 
     dotnet_library(
-      name = "foo_bar",
+      name = "foo_bar.dll",
       srcs = [
           "foo.cs",
           "bar.cs",
@@ -160,12 +160,15 @@ Examples
       ],
     )
 
+  Note: The defined library must have extension .dll. Otherwise launchers used by rules_dotnet are not able 
+  to correctly locate necessary files. 
+
 * dotnet_binary_
 
   .. code:: python
 
     dotnet_binary(
-      name = "foo_bar",
+      name = "foo_bar.exe",
       srcs = [
           "foo.cs",
           "bar.cs",
@@ -177,12 +180,15 @@ Examples
       visibility = ["//visibility:public"],
     )
 
+  Note: The defined library must have extension .exe. Otherwise launchers used by rules_dotnet are not able 
+  to correctly locate necessary files. 
+
 * dotnet_nunit_test_
 
   .. code:: python
 
     dotnet_nunit_test(
-        name = "MyTest",
+        name = "MyTest.dll",
         srcs = [
             "MyTest.cs",
         ],
@@ -191,6 +197,9 @@ Examples
             "//dotnet/externals/nunit2:nunit.framework",
         ],
     )
+
+  Note: The defined library must have extension .dll. Otherwise launchers used by rules_dotnet are not able 
+  to correctly locate necessary files. 
 
 * dotnet_resx_
 
@@ -243,7 +252,7 @@ Examples
   .. code:: python
 
     dotnet_binary(
-        name = "foo_bar",
+        name = "foo_bar.exe",
         srcs = [
             "foo.cs",
             "bar.cs",
@@ -285,7 +294,7 @@ Examples
   .. code:: python
 
     dotnet_binary(
-        name = "foo_bar",
+        name = "foo_bar.exe",
         srcs = [
             "foo.cs",
             "bar.cs",

--- a/dotnet/core.rst
+++ b/dotnet/core.rst
@@ -49,7 +49,7 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`name`              | :type:`string`              | |mandatory|                           |
 +----------------------------+-----------------------------+---------------------------------------+
-| A unique name for this rule.                                                                     |
+| A unique name for this rule. It must have .dll extension.                                        |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`deps`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
@@ -93,7 +93,7 @@ Example
 .. code:: python
 
   dotnet_library(
-      name = "foo_bar",
+      name = "foo_bar.dll",
       srcs = [
           "foo.cs",
           "bar.cs",
@@ -106,7 +106,7 @@ Example
   )
 
   [core_library(
-    name = "{}_TransitiveClass-core".format(framework),
+    name = "{}_TransitiveClass-core.dll".format(framework),
     srcs = [
         "TransitiveClass.cs",
     ],
@@ -140,7 +140,7 @@ Attributes
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`name`              | :type:`string`              | |mandatory|                           |
 +----------------------------+-----------------------------+---------------------------------------+
-| A unique name for this rule.                                                                     |
+| A unique name for this rule. It must have .exe extension.                                        |
 +----------------------------+-----------------------------+---------------------------------------+
 | :param:`deps`              | :type:`label_list`          | :value:`None`                         |
 +----------------------------+-----------------------------+---------------------------------------+
@@ -184,7 +184,7 @@ Example
 .. code:: python
 
   dotnet_binary(
-      name = "foo_bar",
+      name = "foo_bar.exe",
       srcs = [
           "foo.cs",
           "bar.cs",
@@ -220,7 +220,7 @@ Attributes
 +----------------------------+-----------------------------+--------------------------------------------+
 | :param:`name`              | :type:`string`              | |mandatory|                                |
 +----------------------------+-----------------------------+--------------------------------------------+
-| A unique name for this rule.                                                                          |
+| A unique name for this rule. It must have .dll extension.                                             |
 +----------------------------+-----------------------------+--------------------------------------------+
 | :param:`deps`              | :type:`label_list`          | :value:`None`                              |
 +----------------------------+-----------------------------+--------------------------------------------+
@@ -257,7 +257,7 @@ Test example
 .. code:: python
 
     dotnet_nunit_test(
-        name = "MyTest",
+        name = "MyTest.dll",
         srcs = [
             "MyTest.cs",
         ],


### PR DESCRIPTION
Updates main documentation file and rules documentation to reflect the extenstion names required.

fix #148