### PR TITLE
Add netcoreapp3.1 support

### DIFF
--- a/dotnet/platform/list.bzl
+++ b/dotnet/platform/list.bzl
@@ -63,8 +63,9 @@ DOTNET_CORE_FRAMEWORKS = {
     "v2.2.101": (".NETCore,Version=v2.2", "NETCOREAPP2_2", "netcoreapp2.2"),
     "v2.2.402": (".NETCore,Version=v2.2", "NETCOREAPP2_2", "netcoreapp2.2"),
     "v3.0.100": (".NETCore,Version=v3.0", "NETCOREAPP3_0", "netcoreapp3.0"),
+    "v3.1.100": (".NETCore,Version=v3.1", "NETCOREAPP3_1", "netcoreapp3.1"),
 }
-DEFAULT_DOTNET_CORE_FRAMEWORK = "v3.0.100"
+DEFAULT_DOTNET_CORE_FRAMEWORK = "v3.1.100"
 
 def declare_config_settings():
     for impl in DOTNETIMPL:

--- a/dotnet/stdlib.core/v3.1.100/BUILD.bazel
+++ b/dotnet/stdlib.core/v3.1.100/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_dotnet//dotnet/stdlib.core:macro.bzl", "all_core_stdlib", "all_core_stdlib215")
+load("@io_bazel_rules_dotnet//dotnet/private:rules/stdlib.bzl", "core_stdlib")
+
+framework = "v3.1.100"
+
+all_core_stdlib(framework)
+
+all_core_stdlib215(framework)

--- a/dotnet/toolchain/toolchains.bzl
+++ b/dotnet/toolchain/toolchains.bzl
@@ -139,21 +139,21 @@ CORE_SDK_REPOSITORIES = {
         # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-windows-x64-binaries
         "core_windows_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-3.1.100-win-x64.zip",
-            "ABCD034B230365D9454459E271E118A851969D82516B1529EE0BFEA07F7AAE52",
+            "abcd034b230365d9454459e271e118a851969d82516b1529ee0bfea07f7aae52",
             # SHA512 Checsum provided
             # "94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11",
         ),
         # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-linux-x64-binaries
         "core_linux_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/d731f991-8e68-4c7c-8ea0-fad5605b077a/49497b5420eecbd905158d86d738af64/dotnet-sdk-3.1.100-linux-x64.tar.gz",
-            "3687B2A150CD5FEF6D60A4693B4166994F32499C507CD04F346B6DDA38ECDC46",
+            "3687b2a150cd5fef6d60a4693b4166994f32499c507cd04f346b6dda38ecdc46",
             # SHA512 Checsum provided
             # "5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21",
         ),
         # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-macos-x64-binaries
         "core_darwin_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/bea99127-a762-4f9e-aac8-542ad8aa9a94/afb5af074b879303b19c6069e9e8d75f/dotnet-sdk-3.1.100-osx-x64.tar.gz",
-            "B38E6F8935D4B82B283D85C6B83CD24B5253730BAB97E0E5E6F4C43E2B741AAB",
+            "b38e6f8935d4b82b283d85c6b83cd24b5253730bab97e0e5e6f4c43e2b741aab",
             # SHA512 Checsum provided
             # "142922cfb98b0cae6b194c3da2478fdf70f2a67603d248bbf859938bd05c4a4a5facea05d49b0db8b382d8cf73f9a45246a2022c9cf0ccf1501b1138cd0b3e76",
         ),

--- a/dotnet/toolchain/toolchains.bzl
+++ b/dotnet/toolchain/toolchains.bzl
@@ -135,6 +135,23 @@ CORE_SDK_REPOSITORIES = {
             "f0f8af049e0ecbeea9c9c37c16679d6fc2cd4c165510b00e3fad3cd8d0fe0160",
         ),
     },
+    "v3.1.100": {
+        # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-windows-x64-binaries
+        "core_windows_amd64": (
+            "https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-3.1.100-win-x64.zip",
+            "94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11",
+        ),
+        # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-linux-x64-binaries
+        "core_linux_amd64": (
+            "https://download.visualstudio.microsoft.com/download/pr/d731f991-8e68-4c7c-8ea0-fad5605b077a/49497b5420eecbd905158d86d738af64/dotnet-sdk-3.1.100-linux-x64.tar.gz",
+            "5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21",
+        ),
+        # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-macos-x64-binaries
+        "core_darwin_amd64": (
+            "https://download.visualstudio.microsoft.com/download/pr/bea99127-a762-4f9e-aac8-542ad8aa9a94/afb5af074b879303b19c6069e9e8d75f/dotnet-sdk-3.1.100-osx-x64.tar.gz",
+            "142922cfb98b0cae6b194c3da2478fdf70f2a67603d248bbf859938bd05c4a4a5facea05d49b0db8b382d8cf73f9a45246a2022c9cf0ccf1501b1138cd0b3e76",
+        ),
+    },
 }
 
 NET_ROSLYN_REPOSITORIES = {

--- a/dotnet/toolchain/toolchains.bzl
+++ b/dotnet/toolchain/toolchains.bzl
@@ -139,17 +139,23 @@ CORE_SDK_REPOSITORIES = {
         # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-windows-x64-binaries
         "core_windows_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/28a2c4ff-6154-473b-bd51-c62c76171551/ea47eab2219f323596c039b3b679c3d6/dotnet-sdk-3.1.100-win-x64.zip",
-            "94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11",
+            "ABCD034B230365D9454459E271E118A851969D82516B1529EE0BFEA07F7AAE52",
+            # SHA512 Checsum provided
+            # "94ee575d6104058cdd31370fc686b5d1aa23bf4a54611843c1f93afc82cad3523217b5f2eaddd4b5c136bca252d2c9047092f7054052c8683fa0f363ca28ad11",
         ),
         # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-linux-x64-binaries
         "core_linux_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/d731f991-8e68-4c7c-8ea0-fad5605b077a/49497b5420eecbd905158d86d738af64/dotnet-sdk-3.1.100-linux-x64.tar.gz",
-            "5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21",
+            "3687B2A150CD5FEF6D60A4693B4166994F32499C507CD04F346B6DDA38ECDC46",
+            # SHA512 Checsum provided
+            # "5217ae1441089a71103694be8dd5bb3437680f00e263ad28317665d819a92338a27466e7d7a2b1f6b74367dd314128db345fa8fff6e90d0c966dea7a9a43bd21",
         ),
         # https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.100-macos-x64-binaries
         "core_darwin_amd64": (
             "https://download.visualstudio.microsoft.com/download/pr/bea99127-a762-4f9e-aac8-542ad8aa9a94/afb5af074b879303b19c6069e9e8d75f/dotnet-sdk-3.1.100-osx-x64.tar.gz",
-            "142922cfb98b0cae6b194c3da2478fdf70f2a67603d248bbf859938bd05c4a4a5facea05d49b0db8b382d8cf73f9a45246a2022c9cf0ccf1501b1138cd0b3e76",
+            "B38E6F8935D4B82B283D85C6B83CD24B5253730BAB97E0E5E6F4C43E2B741AAB",
+            # SHA512 Checsum provided
+            # "142922cfb98b0cae6b194c3da2478fdf70f2a67603d248bbf859938bd05c4a4a5facea05d49b0db8b382d8cf73f9a45246a2022c9cf0ccf1501b1138cd0b3e76",
         ),
     },
 }


### PR DESCRIPTION
Based on changes in [this](https://github.com/tomdegoede/rules_dotnet/commit/6434be6e9f82c343744812a2f318031537cdb50d) commit. I am not sure how the changes in macro.bzl were determined here, but I don't think they are necessary for adding a minor version.