### PR TITLE
Make the dotnet (mono) rules work sandboxed

### DIFF
--- a/dotnet/private/actions/assembly.bzl
+++ b/dotnet/private/actions/assembly.bzl
@@ -146,7 +146,7 @@ def emit_assembly(
 
     deps_files = [d[DotnetLibrary].result for d in transitive.to_list()]
     dotnet.actions.run(
-        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
+        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib, dotnet.mcs] + [r[DotnetResource].result for r in resources],
         outputs = [result] + ([pdb] if pdb else []),
         executable = dotnet.runner,
         arguments = [dotnet.mcs.path, "/noconfig", "@" + paramfile.path],

--- a/dotnet/private/actions/assembly_core.bzl
+++ b/dotnet/private/actions/assembly_core.bzl
@@ -144,7 +144,7 @@ def emit_assembly_core(
 
     deps_files = [d[DotnetLibrary].result for d in transitive.to_list()]
     dotnet.actions.run(
-        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib] + [r[DotnetResource].result for r in resources],
+        inputs = attr_srcs + [paramfile] + deps_files + [dotnet.stdlib, dotnet.mcs] + [r[DotnetResource].result for r in resources],
         outputs = [result] + ([pdb] if pdb else []),
         executable = dotnet.runner,
         arguments = [dotnet.mcs.path, "/noconfig", "@" + paramfile.path],

--- a/dotnet/private/actions/resx.bzl
+++ b/dotnet/private/actions/resx.bzl
@@ -55,7 +55,7 @@ def emit_resx(
     args = _make_runner_arglist(dotnet, src, result)
 
     dotnet.actions.run(
-        inputs = [copied_source],
+        inputs = [copied_source, dotnet.resgen],
         outputs = [result],
         executable = dotnet.runner,
         arguments = [dotnet.resgen.path, copied_source.path],

--- a/dotnet/private/rules/runfiles.bzl
+++ b/dotnet/private/rules/runfiles.bzl
@@ -10,10 +10,10 @@ def CopyRunfiles(dotnet, runfiles, copy, symlink, executable, subdir):
             newfile = dotnet.declare_file(dotnet, path = subdir + f.basename)
             dotnet.actions.run(
                 outputs = [newfile],
-                inputs = [f],
-                executable = symlink.files.to_list()[0],
+                inputs = [f, dotnet.runner],
+                executable = copy.files.to_list()[0],
                 arguments = [newfile.path, f.path],
-                mnemonic = "LinkFile",
+                mnemonic = "CopyFile",
             )
             created.append(newfile)
         elif f.basename != executable.result.basename:


### PR DESCRIPTION
In order to make the the actions work sandboxed on linux, all files that are needed for the actions needs to be declared.

Out of all actions.run, 3 needs to be updated, the rest are ok.

Also, when the inputs are declared, the error in the runfiles action gets exposed (you cannot assume the symlink is valid to the binary action, since the toolchain is not part of the action itself).

To be safe, the binary should be copied, and not symlinked.