### PR TITLE
Define Windows flag if it is not available

### DIFF
--- a/dotnet/tools/common/manifest.c
+++ b/dotnet/tools/common/manifest.c
@@ -11,6 +11,9 @@
 #include <process.h>
 #define F_OK 0
 #pragma comment(lib, "shlwapi.lib")
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x2
+#endif
 #else
 #include <unistd.h>
 #include <errno.h>

--- a/dotnet/tools/symlink/main.c
+++ b/dotnet/tools/symlink/main.c
@@ -9,6 +9,9 @@
 #include <process.h>
 #define F_OK 0
 #pragma comment(lib, "shlwapi.lib")
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x2
+#endif
 #else
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
The `SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE` was introduced fairly recently in the Windows SDK, making it unavailable in some environments.

This PR defines it if not available. It is defined to its actual value, so if the underlying Windows version supports it but the Windows SDK is outdated, the feature will still work.

The same workaround is available in [bazel itself](https://github.com/bazelbuild/bazel/blob/master/src/main/tools/build-runfiles-windows.cc#L39)