### PR TITLE
nuget2bazel: add runtime files to the generated files list

### DIFF
--- a/tools/nuget2bazel/ProjectBazelManipulator.cs
+++ b/tools/nuget2bazel/ProjectBazelManipulator.cs
@@ -159,11 +159,12 @@ namespace nuget2bazel
             var toolItemGroups = await packageContentReader.GetToolItemsAsync(token);
             var depsGroups = await packageContentReader.GetPackageDependenciesAsync(token);
 
-            // Very ugly hack to extract build folder content
+            // Very ugly hack to extract build folder and runtimes folder content
             // Unfortunately, the original implementation only returns .prop and .targets files.
             var readerBase = (PackageReaderBase)packageContentReader;
             var dynMethod = readerBase.GetType().BaseType.GetMethod("GetFileGroups", BindingFlags.NonPublic | BindingFlags.Instance);
             var allBuildFileGroups = (IEnumerable<FrameworkSpecificGroup>)dynMethod.Invoke(readerBase, new object?[] { "build" });
+            var allRuntimes = (IEnumerable<FrameworkSpecificGroup>)dynMethod.Invoke(readerBase, new object?[] { "runtimes" });
 
             IEnumerable<FrameworkSpecificGroup> refItemGroups = null;
 
@@ -178,7 +179,7 @@ namespace nuget2bazel
                 sha256 = GetSha(downloadResourceResult.PackageStream);
             }
             var entry = new WorkspaceEntry(json.dependencies, packageIdentity, sha256,
-                depsGroups, libItemGroups, toolItemGroups, refItemGroups, allBuildFileGroups, _mainFile, _variable, _nugetSourceCustom);
+                depsGroups, libItemGroups, toolItemGroups, refItemGroups, allBuildFileGroups, allRuntimes, _mainFile, _variable, _nugetSourceCustom);
 
             _entries.Add(packageIdentity, entry);
             await AddEntry(entry);


### PR DESCRIPTION
Some NuGet packages require native libraries to execute. This change
adds the native binaries packed in the NuGet package to the files listed
in the nuget_package rule.

This PR fixes https://github.com/bazelbuild/rules_dotnet/issues/205