### PR TITLE
Fail on missing extensions

### DIFF
--- a/dotnet/private/rules/csharp/binary.bzl
+++ b/dotnet/private/rules/csharp/binary.bzl
@@ -8,6 +8,9 @@ load("@io_bazel_rules_dotnet//dotnet/private:rules/common.bzl", "wrap_binary")
 
 def _binary_impl(ctx):
     """_binary_impl emits actions for compiling executable assembly."""
+    if not ctx.label.name.endswith(".exe") and not ctx.label.name.endswith(".dll"):
+        fail("All csharp_binary targets must have their extension declared in their name (.dll or .exe)")
+
     dotnet = dotnet_context(ctx, "csharp")
     name = ctx.label.name
     subdir = name + "/"

--- a/dotnet/private/rules/csharp/library.bzl
+++ b/dotnet/private/rules/csharp/library.bzl
@@ -11,6 +11,9 @@ load("@io_bazel_rules_dotnet//dotnet/private:rules/versions.bzl", "parse_version
 
 def _library_impl(ctx):
     """_library_impl emits actions for compiling dotnet executable assembly."""
+    if not ctx.label.name.endswith(".exe") and not ctx.label.name.endswith(".dll"):
+        fail("All csharp_library targets must have their extension declared in their name (.dll or .exe)")
+
     dotnet = dotnet_context(ctx, "csharp")
     name = ctx.label.name
 

--- a/dotnet/private/rules/csharp/test.bzl
+++ b/dotnet/private/rules/csharp/test.bzl
@@ -6,6 +6,9 @@ load("@io_bazel_rules_dotnet//dotnet/private:rules/versions.bzl", "parse_version
 load("@io_bazel_rules_dotnet//dotnet/private:rules/common.bzl", "wrap_binary")
 
 def _unit_test(ctx):
+    if not ctx.label.name.endswith(".exe") and not ctx.label.name.endswith(".dll"):
+        fail("All csharp_xunit_test/csharp_nunit3_test targets must have their extension declared in their name (.dll or .exe)")
+
     dotnet = dotnet_context(ctx, "csharp")
     name = ctx.label.name
     subdir = name + "/"

--- a/dotnet/private/rules/fsharp/binary.bzl
+++ b/dotnet/private/rules/fsharp/binary.bzl
@@ -8,6 +8,9 @@ load("@io_bazel_rules_dotnet//dotnet/private:rules/common.bzl", "wrap_binary")
 
 def _binary_impl(ctx):
     """_binary_impl emits actions for compiling executable assembly."""
+    if not ctx.label.name.endswith(".exe") and not ctx.label.name.endswith(".dll"):
+        fail("All fsharp_binary targets must have their extension declared in their name (.dll or .exe)")
+
     dotnet = dotnet_context(ctx, "fsharp")
     name = ctx.label.name
     subdir = name + "/"

--- a/dotnet/private/rules/fsharp/library.bzl
+++ b/dotnet/private/rules/fsharp/library.bzl
@@ -11,6 +11,9 @@ load("@io_bazel_rules_dotnet//dotnet/private:rules/versions.bzl", "parse_version
 
 def _library_impl(ctx):
     """_library_impl emits actions for compiling dotnet executable assembly."""
+    if not ctx.label.name.endswith(".exe") and not ctx.label.name.endswith(".dll"):
+        fail("All fsharp_library targets must have their extension declared in their name (.dll or .exe)")
+
     dotnet = dotnet_context(ctx, "fsharp")
     name = ctx.label.name
 

--- a/dotnet/private/rules/fsharp/test.bzl
+++ b/dotnet/private/rules/fsharp/test.bzl
@@ -6,6 +6,9 @@ load("@io_bazel_rules_dotnet//dotnet/private:rules/versions.bzl", "parse_version
 load("@io_bazel_rules_dotnet//dotnet/private:rules/common.bzl", "wrap_binary")
 
 def _unit_test(ctx):
+    if not ctx.label.name.endswith(".exe") and not ctx.label.name.endswith(".dll"):
+        fail("All fsharp_xunit_test/fsharp_nunit3_test targets must have their extension declared in their name (.dll or .exe)")
+
     dotnet = dotnet_context(ctx, "fsharp")
     name = ctx.label.name
     subdir = name + "/"


### PR DESCRIPTION
## What?
Prints out an error message when .dll or .exe extension is missing in *_binary/library/test rules

## Why?
For better feedback to the user
Closes #222 