### PR TITLE
Fix remote execution

### DIFF
--- a/dotnet/private/BUILD.core.bazel
+++ b/dotnet/private/BUILD.core.bazel
@@ -46,7 +46,7 @@ filegroup(
         "@bazel_tools//src/conditions:windows": ["core/dotnet.exe"],
         "//conditions:default": ["core/dotnet"],
     }),
-    data = glob(["core/host/**/*"]),
+    data = glob(["core/host/**/*", "core/shared/Microsoft.NETCore.App/**/*"]),
 )
 
 #filegroup(


### PR DESCRIPTION
## What?
Adds missing dependencies for the dotnet runner

## Why?
So that they are sent over the wire when using remote execution