### PR TITLE
specify nuget package targetname with nuget2bazel

### DIFF
--- a/tests/tools/nuget2bazel/ArgsT.cs
+++ b/tests/tools/nuget2bazel/ArgsT.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
+using CommandLine.Text;
+using nuget2bazel;
+using nuget2bazel.rules;
+using Xunit;
+
+namespace nuget2bazel_test
+{
+    public class ArgsT
+    {
+        [Theory]
+        [InlineData("add", typeof(AddVerb))]
+        [InlineData("update", typeof(UpdateVerb))]
+        public void Verbs_SupportTargetNameArgument(string verb, Type verbType)
+        {
+            var parsed = Parser.Default.ParseArguments<AddVerb, UpdateVerb>(new[] { verb, "xunit", "2.4.1", "-t", "foo" });
+
+            Assert.Equal(ParserResultType.Parsed, parsed.Tag);
+
+            parsed.WithParsed<object>(verbObj =>
+            {
+                Assert.IsType(verbType, verbObj);
+                var typed = (AddOrUpdateVerb)verbObj;
+                Assert.Equal("\"foo\"", typed.CustomTargetName);
+                Assert.Equal("foo", typed.TargetName);
+            });
+
+            parsed.WithNotParsed((IEnumerable<Error> errs) =>
+            {
+                Assert.Empty(errs);
+            });
+        }
+
+        [Theory]
+        [InlineData("add", typeof(AddVerb))]
+        [InlineData("update", typeof(UpdateVerb))]
+        public void Verbs_HaveTargetNameAndVariableName_AsMutuallyExclusive(string verb, Type verbType)
+        {
+            var parsed = Parser.Default.ParseArguments<AddVerb, UpdateVerb>(new[] { verb, "xunit", "2.4.1", "-t", "foo", "-v", "bar" });
+
+            Assert.Equal(ParserResultType.NotParsed, parsed.Tag);
+
+            var passed = false;
+
+            parsed.WithNotParsed<object>((IEnumerable<Error> errs) =>
+            {
+                Assert.Collection(errs,
+                    err =>
+                    {
+                        var typed = Assert.IsType<MutuallyExclusiveSetError>(err);
+                        Assert.Equal("variable", typed.SetName);
+                    }, err =>
+                    {
+                        var typed = Assert.IsType<MutuallyExclusiveSetError>(err);
+                        Assert.Equal("target_name", typed.SetName);
+                    });
+
+                passed = true;
+            });
+            Assert.True(passed, "Errors should have been recorded by the parser");
+        }
+
+        [Theory]
+        [InlineData("-t", "\"foo\"")]
+        [InlineData("-v", "foo")]
+        public void VariableName_Works(string argName, string customValue)
+        {
+            var parsed = Parser.Default.ParseArguments<AddVerb, UpdateVerb>(new[] { "add", "xunit", "2.4.1", argName, "foo" });
+
+            Assert.Equal(ParserResultType.Parsed, parsed.Tag);
+
+            parsed.WithParsed<object>(verbObj =>
+            {
+                var typed = Assert.IsType<AddVerb>(verbObj);
+                Assert.Equal(customValue, typed.CustomTargetName);
+            });
+
+            parsed.WithNotParsed((IEnumerable<Error> errs) =>
+            {
+                Assert.Empty(errs);
+            });
+        }
+    }
+}

--- a/tools/nuget2bazel/AddOrUpdateVerb.cs
+++ b/tools/nuget2bazel/AddOrUpdateVerb.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CommandLine;
+
+namespace nuget2bazel
+{
+    public class AddOrUpdateVerb : BaseVerb
+    {
+        [Value(index: 0,
+            Required = true,
+            HelpText = "Package id. ")]
+        public string Package { get; set; }
+
+        [Value(index: 1,
+            Required = true,
+            HelpText = "Package version")]
+        public string Version { get; set; }
+
+        [Option('m', "mainFile",
+            Default = null,
+            HelpText = "Basename of the main file in the libs or tools folder if multiple are present")]
+        public string MainFile { get; set; }
+
+        [Option('s', "skipSha256",
+            HelpText = "If true, do not emit the sha256 value for generated nuget_package rules")]
+        public bool SkipSha256 { get; set; }
+
+        [Option('l', "lowest",
+            Default = false,
+            HelpText = "Dependency behavior. Default is HighestMinor; setting this option changes to Lowest")]
+        public bool Lowest { get; set; }
+
+        [Option('v', "variable",
+            Default = null,
+            SetName = "variable",
+            HelpText = "Variable name to use in nuget_package rule")]
+        public string Variable { get; set; }
+
+        [Option('t',
+            "targetname",
+            Default = null,
+            SetName = "target_name",
+            HelpText = "Target name to use in nuget_package rule")]
+        public string TargetName { get; set; }
+
+        public string CustomTargetName => Variable ?? (TargetName != null ? $"\"{TargetName}\"" : null);
+    }
+}

--- a/tools/nuget2bazel/AddVerb.cs
+++ b/tools/nuget2bazel/AddVerb.cs
@@ -2,36 +2,8 @@ using CommandLine;
 
 namespace nuget2bazel
 {
-    [Verb("add", HelpText = "Adds a pckage to the WORKSPACE and packages.json")]
-    public class AddVerb : BaseVerb
+    [Verb("add", HelpText = "Adds a package to the WORKSPACE and packages.json")]
+    public class AddVerb : AddOrUpdateVerb
     {
-        [Value(index: 0,
-            Required = true,
-            HelpText = "Package id. ")]
-        public string Package { get; set; }
-
-        [Value(index: 1,
-            Required = true,
-            HelpText = "Package version")]
-        public string Version { get; set; }
-
-        [Option('m', "mainFile",
-            Default = null,
-            HelpText = "Basename of the main file in the libs or tools folder if multiple are present")]
-        public string MainFile { get; set; }
-
-        [Option('s', "skipSha256",
-            HelpText = "If true, do not emit the sha256 value for generated nuget_package rules")]
-        public bool SkipSha256 { get; set; }
-
-        [Option('l', "lowest",
-            Default = false,
-            HelpText = "Dependency behavior. Default is HighestMinor; setting this option changes to Lowest")]
-        public bool Lowest { get; set; }
-
-        [Option('v', "variable",
-            Default = null,
-            HelpText = "Variable name to use in nuget_package rule")]
-        public string Variable { get; set; }
     }
 }

--- a/tools/nuget2bazel/Program.cs
+++ b/tools/nuget2bazel/Program.cs
@@ -7,16 +7,16 @@ using nuget2bazel.rules;
 
 namespace nuget2bazel
 {
-    class Program
+    internal class Program
     {
-        static async Task Main(string[] args)
+        private static async Task Main(string[] args)
         {
             var parsed = Parser.Default.ParseArguments<AddVerb, DeleteVerb, SyncVerb, UpdateVerb, RulesVerb>(args);
             var result = await parsed.MapResult<AddVerb, DeleteVerb, SyncVerb, UpdateVerb, RulesVerb, Task<int>>(
                 async (AddVerb opts) =>
                 {
                     var prjConfig = new ProjectBazelConfig(opts);
-                    await new AddCommand().Do(prjConfig, opts.Package, opts.Version, opts.MainFile, opts.SkipSha256, opts.Lowest, opts.Variable);
+                    await new AddCommand().Do(prjConfig, opts.Package, opts.Version, opts.MainFile, opts.SkipSha256, opts.Lowest, opts.CustomTargetName);
                     return 0;
                 },
                 async (DeleteVerb opts) =>
@@ -34,7 +34,7 @@ namespace nuget2bazel
                 async (UpdateVerb opts) =>
                 {
                     var prjConfig = new ProjectBazelConfig(opts);
-                    await new UpdateCommand().Do(prjConfig, opts.Package, opts.Version, opts.MainFile, opts.SkipSha256, opts.Lowest, opts.Variable);
+                    await new UpdateCommand().Do(prjConfig, opts.Package, opts.Version, opts.MainFile, opts.SkipSha256, opts.Lowest, opts.CustomTargetName);
                     return 0;
                 },
                 async (RulesVerb opts) =>

--- a/tools/nuget2bazel/UpdateVerb.cs
+++ b/tools/nuget2bazel/UpdateVerb.cs
@@ -9,35 +9,7 @@ using CommandLine;
 namespace nuget2bazel
 {
     [Verb("update", HelpText = "Updates a package in the bazel and config files")]
-    public class UpdateVerb : BaseVerb
+    public class UpdateVerb : AddOrUpdateVerb
     {
-        [Value(index: 0,
-            Required = true,
-            HelpText = "Package id")]
-        public string Package { get; set; }
-
-        [Value(index: 1,
-            Required = true,
-            HelpText = "Package version")]
-        public string Version { get; set; }
-
-        [Option('m', "mainFile",
-            Default = null,
-            HelpText = "Basename of the main file in the libs or tools folder if multiple are present")]
-        public string MainFile { get; set; }
-
-        [Option('s', "skipSha256",
-            HelpText = "If true, do not emit the sha256 value for generated nuget_package rules")]
-        public bool SkipSha256 { get; set; }
-
-        [Option('l', "lowest",
-        Default = false,
-        HelpText = "Dependency behavior. Default is HighestMinor; setting this option changes to Lowest")]
-        public bool Lowest { get; set; }
-
-        [Option('v', "variable",
-            Default = null,
-            HelpText = "Variable name to use in nuget_package rule")]
-        public string Variable { get; set; }
     }
 }


### PR DESCRIPTION
## Usage 
PowerShell (replace $PWD for other shell)
`nuget2bazel.exe add -p $PWD CommandLineParser 1.9.71 -t commandlineparser-v1`

Result: 
```
nuget_package(
    name = "commandlineparser-v1",
    package = "commandlineparser",
    version = "1.9.71",
    sha256 = "e31a20ad0a994c1bf8b085ab4f010030be3b55f80d159a8710583302f1474c53",
)
```

## Why?
This (more easily) supports cases where you must use multiple versions of the same nuget pacakage in your workspace. i.e. You have the capacity to upgrade one project but not all projects that depend on the package, or you want to try out a breaking major version in one project, but not the whole repo.

While this can be accomplished with escaping quotes passed to -v, escaping quotes is hard:
- https://stackoverflow.com/questions/653563/passing-command-line-arguments-in-c-sharp
- https://adamtheautomator.com/powershell-escape-double-quotes/#Double_Quotes
- https://stackoverflow.com/questions/9287812/backslash-and-quote-in-command-line-arguments

In PowerShell on Windows, I was unable to get the output `"commandlineparser-v1"` using -v
1. `-v "commandlineparser-v1"` produces `commandlineparser-v1` (variable name)
2. `-v '"commandlineparser-v1"'` produces `commandlineparser-v1` (varialbe name)
3. -v ``'`"commandlineparser-v1`"'`` produces ```commandlineparser-v1``` (backticks included)
4. -v `"""commandlineparser-v1"""` produces `commandlineparser-v1` (variable name)
5. -v `"\"commandlineparser-v1\""` produces `\` (invalid)
6. -v `'\\"commandlineparser-v1\\"'` produces `\commandlineparser-v1\`

