### PR TITLE
Add support for extracting nuget packages from project files

### DIFF
--- a/tests/tools/nuget2bazel/ProjectFileParserT.cs
+++ b/tests/tools/nuget2bazel/ProjectFileParserT.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using System.IO;
+using System.Threading.Tasks;
+using nuget2bazel;
+using Xunit;
+
+namespace nuget2bazel_test
+{
+    public class ProjectFileParserT : TestBase
+    {
+        private static string project1 = @"
+            <Project Sdk='Microsoft.NET.Sdk'>
+                <PropertyGroup>
+                    <TargetFramework>netcoreapp3.1</TargetFramework>
+                    <RootNamespace>nuget2bazel_test</RootNamespace>
+                    <IsPackable>false</IsPackable>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include='xunit' Version='2.4.0' />
+                </ItemGroup>
+            </Project>
+            ";
+
+        // Second project file with a duplicate nuget package 
+        private static string project2 = @"
+            <Project Sdk='Microsoft.NET.Sdk'>
+                <PropertyGroup>
+                    <TargetFramework>netcoreapp3.1</TargetFramework>
+                    <RootNamespace>nuget2bazel_test</RootNamespace>
+                    <IsPackable>false</IsPackable>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include='xunit.runner.visualstudio' Version='2.4.1' />
+                    <PackageReference Include='xunit' Version='2.4.0' />
+                </ItemGroup>
+            </Project>
+            ";    
+
+        [Fact]
+        public async Task ParseSingleProjectFile()
+        {
+            var projectFileParser = new ProjectFileParser(_prjConfig);
+            
+            _prjConfig.ProjectFiles = "project1.csproj";
+            await File.WriteAllTextAsync($"{_prjConfig.RootPath}/project1.csproj", project1);
+
+            var packages = projectFileParser.GetNugetPackages();
+
+            Assert.Equal(1, packages.Count);
+            Assert.Equal("xunit", packages[0].Name);
+            Assert.Equal("2.4.0", packages[0].Version);
+        }
+
+        [Fact]
+        public async Task ParseMultipleProjectFiles()
+        {
+            var projectFileParser = new ProjectFileParser(_prjConfig);
+            
+            _prjConfig.ProjectFiles = "project1.csproj project2.csproj";
+            await File.WriteAllTextAsync($"{_prjConfig.RootPath}/project1.csproj", project1);
+            await File.WriteAllTextAsync($"{_prjConfig.RootPath}/project2.csproj", project2);
+
+            var packages = projectFileParser.GetNugetPackages();
+
+            Assert.Equal(2, packages.Count);
+
+            Assert.Equal("xunit", packages[0].Name);
+            Assert.Equal("2.4.0", packages[0].Version);
+
+            Assert.Equal("xunit.runner.visualstudio", packages[1].Name);
+            Assert.Equal("2.4.1", packages[1].Version);
+        } 
+    }
+}

--- a/tools/nuget2bazel/AddCommand.cs
+++ b/tools/nuget2bazel/AddCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading;
@@ -23,6 +24,16 @@ namespace nuget2bazel
         {
             var project = new ProjectBazelManipulator(prjConfig, mainFile, skipSha256, variable);
 
+            if(prjConfig.ProjectFiles != null)
+            {
+                var projectFileParser = new ProjectFileParser(prjConfig);
+                var packages = projectFileParser.GetNugetPackages();
+                
+                var nugetTasks = packages.Select(p => DoWithProject(prjConfig.NugetSource, p.Name, p.Version, project, lowest)).ToArray();
+                
+                return Task.WhenAll(nugetTasks);
+            }
+            
             return DoWithProject(prjConfig.NugetSource, package, version, project, lowest);
         }
         public async Task DoWithProject(string nugetSource, string package, string version, ProjectBazelManipulator project, bool lowest)

--- a/tools/nuget2bazel/AddOrUpdateVerb.cs
+++ b/tools/nuget2bazel/AddOrUpdateVerb.cs
@@ -8,12 +8,12 @@ namespace nuget2bazel
     public class AddOrUpdateVerb : BaseVerb
     {
         [Value(index: 0,
-            Required = true,
+            Required = false,
             HelpText = "Package id. ")]
         public string Package { get; set; }
 
         [Value(index: 1,
-            Required = true,
+            Required = false,
             HelpText = "Package version")]
         public string Version { get; set; }
 

--- a/tools/nuget2bazel/BaseVerb.cs
+++ b/tools/nuget2bazel/BaseVerb.cs
@@ -33,5 +33,10 @@ namespace nuget2bazel
             Default = false,
             HelpText = "Should nuget_package reference source variable")]
         public bool NugetSourceCustom { get; set; }
+
+        [Option('f', "Visual Studio project files",
+            Default = null,
+            HelpText = "project files")]
+        public string ProjectFiles { get; set; }
     }
 }

--- a/tools/nuget2bazel/ProjectBazelConfig.cs
+++ b/tools/nuget2bazel/ProjectBazelConfig.cs
@@ -10,6 +10,7 @@ namespace nuget2bazel
         public ProjectBazelConfig(string root)
         {
             RootPath = root;
+            
             Nuget2BazelConfigName = "nuget2config.json";
             BazelFileName = "WORKSPACE";
             Indent = false;
@@ -18,6 +19,8 @@ namespace nuget2bazel
         }
         public ProjectBazelConfig(BaseVerb verb)
         {
+            ProjectFiles = verb.ProjectFiles;
+
             RootPath = verb.RootPath;
             if (RootPath == null)
                 RootPath = Directory.GetCurrentDirectory();
@@ -35,5 +38,6 @@ namespace nuget2bazel
         public string NugetSource { get; set; }
         public bool NugetSourceCustom { get; set; }
         public bool Indent { get; set; }
+        public string ProjectFiles { get; set; }
     }
 }

--- a/tools/nuget2bazel/ProjectFileParser.cs
+++ b/tools/nuget2bazel/ProjectFileParser.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Collections.Generic;
+
+namespace nuget2bazel
+{
+    public class ProjectFileNugetPackage
+    {
+        public string Name {get; set;}
+        public string Version {get; set;}
+    }
+
+    public class ProjectFileParser
+    {
+        private readonly ProjectBazelConfig prjConfig;
+        public ProjectFileParser(ProjectBazelConfig prjConfig)
+        {
+            this.prjConfig = prjConfig;
+        }
+
+        public List<ProjectFileNugetPackage> GetNugetPackages()
+        {
+            var nugetPackages = new List<ProjectFileNugetPackage>();
+            var packages = new Dictionary<string, string>();
+
+            foreach(var projectFile in prjConfig.ProjectFiles.Split(' '))
+            {
+                var projectXml = XElement.Load($"{prjConfig.RootPath}{Path.DirectorySeparatorChar}{projectFile}");
+
+                foreach(var p in projectXml.Element("ItemGroup").Descendants("PackageReference"))
+                {
+                    var name = p.Attribute("Include").Value;
+                    var version = p.Attribute("Version").Value;
+                    var key = $"{name}-{version}";
+                    
+                    if(!packages.ContainsKey(key))
+                    {
+                        nugetPackages.Add(new ProjectFileNugetPackage() {Name = name, Version = version});
+                        packages.Add(key, key);
+                    }
+                }
+            }
+
+            return nugetPackages;
+        }
+    }
+}


### PR DESCRIPTION
Proposing an addition to the Nuget2Bazel tool that will allow us to extract nuget packages from VS project files. 

Not sure if the command line interface is ideal, but I have added a new option (-f) as seen below:

```
bazel run //tools/nuget2bazel:nuget2bazel.exe -- add -p [WORKSPACE path] -f project1.csproj subfolder/project2.csproj
```
The list of project files is space delimited, and any overlapping packages will be de-duped.

Thoughts?