### PR TITLE
Fix the `out` attribute

### DIFF
--- a/dotnet/private/rules/common/binary.bzl
+++ b/dotnet/private/rules/common/binary.bzl
@@ -95,7 +95,7 @@ def build_binary(ctx, compile_action):
     depsjson = None
     if is_core_framework(tfm):
         # Create the runtimeconfig.json for the binary
-        runtimeconfig = ctx.actions.declare_file("bazelout/%s/%s.runtimeconfig.json" % (tfm, ctx.attr.name))
+        runtimeconfig = ctx.actions.declare_file("bazelout/%s/%s.runtimeconfig.json" % (tfm, ctx.attr.out or ctx.attr.name))
         runtimeconfig_struct = generate_runtimeconfig(
             target_framework = tfm,
             project_sdk = ctx.attr.project_sdk,
@@ -117,7 +117,7 @@ def build_binary(ctx, compile_action):
             content = json.encode_indent(runtimeconfig_struct),
         )
 
-        depsjson = ctx.actions.declare_file("bazelout/%s/%s.deps.json" % (tfm, ctx.attr.name))
+        depsjson = ctx.actions.declare_file("bazelout/%s/%s.deps.json" % (tfm, ctx.attr.out or ctx.attr.name))
         depsjson_struct = generate_depsjson(
             ctx,
             target_framework = tfm,

--- a/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
+++ b/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
@@ -130,7 +130,7 @@ def AssemblyAction(
         exports_files,
         overrides,
     ) = collect_transitive_info(
-        target_name,
+        assembly_name,
         deps + [toolchain.host_model] if include_host_model_dll else deps,
         private_deps,
         exports,
@@ -186,7 +186,7 @@ def AssemblyAction(
 
         internals_visible_to_cs = _write_internals_visible_to_csharp(
             actions,
-            name = target_name,
+            name = assembly_name,
             others = internals_visible_to,
         )
 

--- a/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
+++ b/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
@@ -146,7 +146,7 @@ def AssemblyAction(
         exports_files,
         overrides,
     ) = collect_transitive_info(
-        target_name,
+        assembly_name,
         deps,
         private_deps,
         exports,
@@ -196,7 +196,7 @@ def AssemblyAction(
 
         internals_visible_to_fs = _write_internals_visible_to_fsharp(
             actions,
-            name = target_name,
+            name = assembly_name,
             others = internals_visible_to,
         )
         _compile(

--- a/dotnet/private/tests/out/csharp/BUILD.bazel
+++ b/dotnet/private/tests/out/csharp/BUILD.bazel
@@ -1,0 +1,35 @@
+"Test that the `out` attribute works as expected"
+
+load(
+    "@rules_dotnet//dotnet:defs.bzl",
+    "csharp_library",
+    "csharp_nunit_test",
+)
+
+csharp_nunit_test(
+    name = "lib_test",
+    srcs = ["libtest.cs"],
+    out = "OtherLibTest",
+    private_deps = [
+        "@rules_dotnet_dev_nuget_packages//microsoft.netcore.app.ref",
+    ],
+    target_frameworks = ["net6.0"],
+    deps = [
+        ":lib",
+    ],
+)
+
+csharp_library(
+    name = "lib",
+    srcs = ["lib.cs"],
+    out = "OtherLib",
+    # Note that the we use the name that is used in the `out` attribute of the `lib_test` target.
+    internals_visible_to = [
+        "OtherLibTest",
+    ],
+    private_deps = [
+        "@rules_dotnet_dev_nuget_packages//microsoft.netcore.app.ref",
+    ],
+    target_frameworks = ["net6.0"],
+    deps = [],
+)

--- a/dotnet/private/tests/out/csharp/lib.cs
+++ b/dotnet/private/tests/out/csharp/lib.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Lib
+{
+    public static class Stuff
+    {
+        public static bool IsTrue()
+        {
+            return true;
+        }
+        internal static bool IsTrueInternal()
+        {
+            return true;
+        }
+    }
+}

--- a/dotnet/private/tests/out/csharp/libtest.cs
+++ b/dotnet/private/tests/out/csharp/libtest.cs
@@ -1,0 +1,20 @@
+using Lib;
+using NUnit.Framework;
+using System.Linq;
+
+[TestFixture]
+public sealed class LibTests
+{
+    [Test]
+    public void SomeTest()
+    {
+        Assert.AreEqual(true, Stuff.IsTrue());
+    }
+
+    [Test]
+    public void SomeTestInternal()
+    {
+        Assert.AreEqual(true, Stuff.IsTrueInternal());
+    }
+}
+

--- a/dotnet/private/tests/out/fsharp/BUILD.bazel
+++ b/dotnet/private/tests/out/fsharp/BUILD.bazel
@@ -1,0 +1,38 @@
+"Test that the `out` attribute works as expected"
+
+load(
+    "@rules_dotnet//dotnet:defs.bzl",
+    "fsharp_library",
+    "fsharp_nunit_test",
+)
+
+fsharp_nunit_test(
+    name = "lib_test",
+    srcs = ["libtest.fs"],
+    out = "OtherLibTest",
+    private_deps = [
+        "@rules_dotnet_dev_nuget_packages//microsoft.netcore.app.ref",
+    ],
+    target_frameworks = ["net6.0"],
+    deps = [
+        ":lib",
+        "@rules_dotnet_dev_nuget_packages//fsharp.core",
+    ],
+)
+
+fsharp_library(
+    name = "lib",
+    srcs = ["lib.fs"],
+    out = "OtherLib",
+    # Note that the we use the name that is used in the `out` attribute of the `lib_test` target.
+    internals_visible_to = [
+        "OtherLibTest",
+    ],
+    private_deps = [
+        "@rules_dotnet_dev_nuget_packages//microsoft.netcore.app.ref",
+    ],
+    target_frameworks = ["net6.0"],
+    deps = [
+        "@rules_dotnet_dev_nuget_packages//fsharp.core",
+    ],
+)

--- a/dotnet/private/tests/out/fsharp/lib.fs
+++ b/dotnet/private/tests/out/fsharp/lib.fs
@@ -1,0 +1,5 @@
+namespace Lib
+
+module Stuff =
+    let isTrue () = true
+    let internal isTrueInternal () = true

--- a/dotnet/private/tests/out/fsharp/libtest.fs
+++ b/dotnet/private/tests/out/fsharp/libtest.fs
@@ -1,0 +1,14 @@
+module Tests
+
+open Lib
+open NUnit.Framework
+open System.Linq
+
+[<TestFixture>]
+type LibTests() =
+    [<Test>]
+    member this.SomeTest() = Assert.AreEqual(true, Stuff.isTrue ())
+
+    [<Test>]
+    member this.SomeTestInternal() =
+        Assert.AreEqual(true, Stuff.isTrueInternal ())

--- a/examples/basic_csharp/BUILD.bazel
+++ b/examples/basic_csharp/BUILD.bazel
@@ -18,10 +18,6 @@ csharp_binary(
     ],
 )
 
-# bazel test //examples:lib_test
-# NOTE: this doesn't work yet because we aren't setting up the runfiles
-# correctly. If you copy out all the dlls/exes to a common folder it does
-# though.
 csharp_nunit_test(
     name = "lib_test",
     srcs = ["libtest.cs"],


### PR DESCRIPTION
## What?
The `out` attribute was broken after we started  generating deps.json and runtimeconfig.json files.
The internals visible to handling was also not correct when using the `out` attribute

Fixes #341
