### PR TITLE
Add attribute to set /nullable flag to C# compiler

### DIFF
--- a/docs/csharp_binary.md
+++ b/docs/csharp_binary.md
@@ -10,12 +10,12 @@ Rule for compiling C# binaries.
 
 <pre>
 csharp_binary(<a href="#csharp_binary-name">name</a>, <a href="#csharp_binary-additionalfiles">additionalfiles</a>, <a href="#csharp_binary-allow_unsafe_blocks">allow_unsafe_blocks</a>, <a href="#csharp_binary-apphost_shimmer">apphost_shimmer</a>, <a href="#csharp_binary-compile_data">compile_data</a>, <a href="#csharp_binary-data">data</a>,
-              <a href="#csharp_binary-defines">defines</a>, <a href="#csharp_binary-deps">deps</a>, <a href="#csharp_binary-include_host_model_dll">include_host_model_dll</a>, <a href="#csharp_binary-internals_visible_to">internals_visible_to</a>, <a href="#csharp_binary-keyfile">keyfile</a>, <a href="#csharp_binary-langversion">langversion</a>, <a href="#csharp_binary-out">out</a>,
-              <a href="#csharp_binary-override_strict_deps">override_strict_deps</a>, <a href="#csharp_binary-override_treat_warnings_as_errors">override_treat_warnings_as_errors</a>, <a href="#csharp_binary-override_warning_level">override_warning_level</a>,
-              <a href="#csharp_binary-override_warnings_as_errors">override_warnings_as_errors</a>, <a href="#csharp_binary-override_warnings_not_as_errors">override_warnings_not_as_errors</a>, <a href="#csharp_binary-private_deps">private_deps</a>, <a href="#csharp_binary-project_sdk">project_sdk</a>,
-              <a href="#csharp_binary-resources">resources</a>, <a href="#csharp_binary-runtime_identifier">runtime_identifier</a>, <a href="#csharp_binary-srcs">srcs</a>, <a href="#csharp_binary-strict_deps">strict_deps</a>, <a href="#csharp_binary-target_frameworks">target_frameworks</a>,
-              <a href="#csharp_binary-treat_warnings_as_errors">treat_warnings_as_errors</a>, <a href="#csharp_binary-warning_level">warning_level</a>, <a href="#csharp_binary-warnings_as_errors">warnings_as_errors</a>, <a href="#csharp_binary-warnings_not_as_errors">warnings_not_as_errors</a>,
-              <a href="#csharp_binary-winexe">winexe</a>)
+              <a href="#csharp_binary-defines">defines</a>, <a href="#csharp_binary-deps">deps</a>, <a href="#csharp_binary-include_host_model_dll">include_host_model_dll</a>, <a href="#csharp_binary-internals_visible_to">internals_visible_to</a>, <a href="#csharp_binary-keyfile">keyfile</a>, <a href="#csharp_binary-langversion">langversion</a>,
+              <a href="#csharp_binary-nullable">nullable</a>, <a href="#csharp_binary-out">out</a>, <a href="#csharp_binary-override_strict_deps">override_strict_deps</a>, <a href="#csharp_binary-override_treat_warnings_as_errors">override_treat_warnings_as_errors</a>,
+              <a href="#csharp_binary-override_warning_level">override_warning_level</a>, <a href="#csharp_binary-override_warnings_as_errors">override_warnings_as_errors</a>, <a href="#csharp_binary-override_warnings_not_as_errors">override_warnings_not_as_errors</a>,
+              <a href="#csharp_binary-private_deps">private_deps</a>, <a href="#csharp_binary-project_sdk">project_sdk</a>, <a href="#csharp_binary-resources">resources</a>, <a href="#csharp_binary-runtime_identifier">runtime_identifier</a>, <a href="#csharp_binary-srcs">srcs</a>, <a href="#csharp_binary-strict_deps">strict_deps</a>,
+              <a href="#csharp_binary-target_frameworks">target_frameworks</a>, <a href="#csharp_binary-treat_warnings_as_errors">treat_warnings_as_errors</a>, <a href="#csharp_binary-warning_level">warning_level</a>, <a href="#csharp_binary-warnings_as_errors">warnings_as_errors</a>,
+              <a href="#csharp_binary-warnings_not_as_errors">warnings_not_as_errors</a>, <a href="#csharp_binary-winexe">winexe</a>)
 </pre>
 
 Compile a C# exe
@@ -37,6 +37,7 @@ Compile a C# exe
 | <a id="csharp_binary-internals_visible_to"></a>internals_visible_to |  Other libraries that can see the assembly's internal symbols. Using this rather than the InternalsVisibleTo assembly attribute will improve build caching.   | List of strings | optional | [] |
 | <a id="csharp_binary-keyfile"></a>keyfile |  The key file used to sign the assembly with a strong name.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="csharp_binary-langversion"></a>langversion |  The version string for the language.   | String | optional | "" |
+| <a id="csharp_binary-nullable"></a>nullable |  Enable nullable context, or nullable warnings.   | String | optional | "disable" |
 | <a id="csharp_binary-out"></a>out |  File name, without extension, of the built assembly.   | String | optional | "" |
 | <a id="csharp_binary-override_strict_deps"></a>override_strict_deps |  Whether or not to override the strict_deps attribute.   | Boolean | optional | False |
 | <a id="csharp_binary-override_treat_warnings_as_errors"></a>override_treat_warnings_as_errors |  Whether or not to override the treat_warnings_as_errors attribute.   | Boolean | optional | False |

--- a/docs/csharp_library.md
+++ b/docs/csharp_library.md
@@ -10,11 +10,11 @@ Rule for compiling C# libraries.
 
 <pre>
 csharp_library(<a href="#csharp_library-name">name</a>, <a href="#csharp_library-additionalfiles">additionalfiles</a>, <a href="#csharp_library-allow_unsafe_blocks">allow_unsafe_blocks</a>, <a href="#csharp_library-compile_data">compile_data</a>, <a href="#csharp_library-data">data</a>, <a href="#csharp_library-defines">defines</a>, <a href="#csharp_library-deps">deps</a>,
-               <a href="#csharp_library-exports">exports</a>, <a href="#csharp_library-internals_visible_to">internals_visible_to</a>, <a href="#csharp_library-keyfile">keyfile</a>, <a href="#csharp_library-langversion">langversion</a>, <a href="#csharp_library-out">out</a>, <a href="#csharp_library-override_strict_deps">override_strict_deps</a>,
-               <a href="#csharp_library-override_treat_warnings_as_errors">override_treat_warnings_as_errors</a>, <a href="#csharp_library-override_warning_level">override_warning_level</a>, <a href="#csharp_library-override_warnings_as_errors">override_warnings_as_errors</a>,
-               <a href="#csharp_library-override_warnings_not_as_errors">override_warnings_not_as_errors</a>, <a href="#csharp_library-private_deps">private_deps</a>, <a href="#csharp_library-project_sdk">project_sdk</a>, <a href="#csharp_library-resources">resources</a>,
-               <a href="#csharp_library-runtime_identifier">runtime_identifier</a>, <a href="#csharp_library-srcs">srcs</a>, <a href="#csharp_library-strict_deps">strict_deps</a>, <a href="#csharp_library-target_frameworks">target_frameworks</a>, <a href="#csharp_library-treat_warnings_as_errors">treat_warnings_as_errors</a>,
-               <a href="#csharp_library-warning_level">warning_level</a>, <a href="#csharp_library-warnings_as_errors">warnings_as_errors</a>, <a href="#csharp_library-warnings_not_as_errors">warnings_not_as_errors</a>)
+               <a href="#csharp_library-exports">exports</a>, <a href="#csharp_library-internals_visible_to">internals_visible_to</a>, <a href="#csharp_library-keyfile">keyfile</a>, <a href="#csharp_library-langversion">langversion</a>, <a href="#csharp_library-nullable">nullable</a>, <a href="#csharp_library-out">out</a>,
+               <a href="#csharp_library-override_strict_deps">override_strict_deps</a>, <a href="#csharp_library-override_treat_warnings_as_errors">override_treat_warnings_as_errors</a>, <a href="#csharp_library-override_warning_level">override_warning_level</a>,
+               <a href="#csharp_library-override_warnings_as_errors">override_warnings_as_errors</a>, <a href="#csharp_library-override_warnings_not_as_errors">override_warnings_not_as_errors</a>, <a href="#csharp_library-private_deps">private_deps</a>,
+               <a href="#csharp_library-project_sdk">project_sdk</a>, <a href="#csharp_library-resources">resources</a>, <a href="#csharp_library-runtime_identifier">runtime_identifier</a>, <a href="#csharp_library-srcs">srcs</a>, <a href="#csharp_library-strict_deps">strict_deps</a>, <a href="#csharp_library-target_frameworks">target_frameworks</a>,
+               <a href="#csharp_library-treat_warnings_as_errors">treat_warnings_as_errors</a>, <a href="#csharp_library-warning_level">warning_level</a>, <a href="#csharp_library-warnings_as_errors">warnings_as_errors</a>, <a href="#csharp_library-warnings_not_as_errors">warnings_not_as_errors</a>)
 </pre>
 
 Compile a C# DLL
@@ -35,6 +35,7 @@ Compile a C# DLL
 | <a id="csharp_library-internals_visible_to"></a>internals_visible_to |  Other libraries that can see the assembly's internal symbols. Using this rather than the InternalsVisibleTo assembly attribute will improve build caching.   | List of strings | optional | [] |
 | <a id="csharp_library-keyfile"></a>keyfile |  The key file used to sign the assembly with a strong name.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="csharp_library-langversion"></a>langversion |  The version string for the language.   | String | optional | "" |
+| <a id="csharp_library-nullable"></a>nullable |  Enable nullable context, or nullable warnings.   | String | optional | "disable" |
 | <a id="csharp_library-out"></a>out |  File name, without extension, of the built assembly.   | String | optional | "" |
 | <a id="csharp_library-override_strict_deps"></a>override_strict_deps |  Whether or not to override the strict_deps attribute.   | Boolean | optional | False |
 | <a id="csharp_library-override_treat_warnings_as_errors"></a>override_treat_warnings_as_errors |  Whether or not to override the treat_warnings_as_errors attribute.   | Boolean | optional | False |

--- a/docs/csharp_test.md
+++ b/docs/csharp_test.md
@@ -13,11 +13,12 @@ a Bazel test.
 
 <pre>
 csharp_test(<a href="#csharp_test-name">name</a>, <a href="#csharp_test-additionalfiles">additionalfiles</a>, <a href="#csharp_test-allow_unsafe_blocks">allow_unsafe_blocks</a>, <a href="#csharp_test-apphost_shimmer">apphost_shimmer</a>, <a href="#csharp_test-compile_data">compile_data</a>, <a href="#csharp_test-data">data</a>,
-            <a href="#csharp_test-defines">defines</a>, <a href="#csharp_test-deps">deps</a>, <a href="#csharp_test-internals_visible_to">internals_visible_to</a>, <a href="#csharp_test-keyfile">keyfile</a>, <a href="#csharp_test-langversion">langversion</a>, <a href="#csharp_test-out">out</a>, <a href="#csharp_test-override_strict_deps">override_strict_deps</a>,
-            <a href="#csharp_test-override_treat_warnings_as_errors">override_treat_warnings_as_errors</a>, <a href="#csharp_test-override_warning_level">override_warning_level</a>, <a href="#csharp_test-override_warnings_as_errors">override_warnings_as_errors</a>,
-            <a href="#csharp_test-override_warnings_not_as_errors">override_warnings_not_as_errors</a>, <a href="#csharp_test-private_deps">private_deps</a>, <a href="#csharp_test-project_sdk">project_sdk</a>, <a href="#csharp_test-resources">resources</a>, <a href="#csharp_test-runtime_identifier">runtime_identifier</a>,
-            <a href="#csharp_test-srcs">srcs</a>, <a href="#csharp_test-strict_deps">strict_deps</a>, <a href="#csharp_test-target_frameworks">target_frameworks</a>, <a href="#csharp_test-treat_warnings_as_errors">treat_warnings_as_errors</a>, <a href="#csharp_test-warning_level">warning_level</a>,
-            <a href="#csharp_test-warnings_as_errors">warnings_as_errors</a>, <a href="#csharp_test-warnings_not_as_errors">warnings_not_as_errors</a>, <a href="#csharp_test-winexe">winexe</a>)
+            <a href="#csharp_test-defines">defines</a>, <a href="#csharp_test-deps">deps</a>, <a href="#csharp_test-internals_visible_to">internals_visible_to</a>, <a href="#csharp_test-keyfile">keyfile</a>, <a href="#csharp_test-langversion">langversion</a>, <a href="#csharp_test-nullable">nullable</a>, <a href="#csharp_test-out">out</a>,
+            <a href="#csharp_test-override_strict_deps">override_strict_deps</a>, <a href="#csharp_test-override_treat_warnings_as_errors">override_treat_warnings_as_errors</a>, <a href="#csharp_test-override_warning_level">override_warning_level</a>,
+            <a href="#csharp_test-override_warnings_as_errors">override_warnings_as_errors</a>, <a href="#csharp_test-override_warnings_not_as_errors">override_warnings_not_as_errors</a>, <a href="#csharp_test-private_deps">private_deps</a>, <a href="#csharp_test-project_sdk">project_sdk</a>,
+            <a href="#csharp_test-resources">resources</a>, <a href="#csharp_test-runtime_identifier">runtime_identifier</a>, <a href="#csharp_test-srcs">srcs</a>, <a href="#csharp_test-strict_deps">strict_deps</a>, <a href="#csharp_test-target_frameworks">target_frameworks</a>,
+            <a href="#csharp_test-treat_warnings_as_errors">treat_warnings_as_errors</a>, <a href="#csharp_test-warning_level">warning_level</a>, <a href="#csharp_test-warnings_as_errors">warnings_as_errors</a>, <a href="#csharp_test-warnings_not_as_errors">warnings_not_as_errors</a>,
+            <a href="#csharp_test-winexe">winexe</a>)
 </pre>
 
 Compiles a C# executable and runs it as a test
@@ -38,6 +39,7 @@ Compiles a C# executable and runs it as a test
 | <a id="csharp_test-internals_visible_to"></a>internals_visible_to |  Other libraries that can see the assembly's internal symbols. Using this rather than the InternalsVisibleTo assembly attribute will improve build caching.   | List of strings | optional | [] |
 | <a id="csharp_test-keyfile"></a>keyfile |  The key file used to sign the assembly with a strong name.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="csharp_test-langversion"></a>langversion |  The version string for the language.   | String | optional | "" |
+| <a id="csharp_test-nullable"></a>nullable |  Enable nullable context, or nullable warnings.   | String | optional | "disable" |
 | <a id="csharp_test-out"></a>out |  File name, without extension, of the built assembly.   | String | optional | "" |
 | <a id="csharp_test-override_strict_deps"></a>override_strict_deps |  Whether or not to override the strict_deps attribute.   | Boolean | optional | False |
 | <a id="csharp_test-override_treat_warnings_as_errors"></a>override_treat_warnings_as_errors |  Whether or not to override the treat_warnings_as_errors attribute.   | Boolean | optional | False |

--- a/dotnet/private/rules/common/attrs.bzl
+++ b/dotnet/private/rules/common/attrs.bzl
@@ -215,6 +215,12 @@ CSHARP_COMMON_ATTRS = dicts.add(
             mandatory = False,
             default = False,
         ),
+        "nullable": attr.string(
+            doc = "Enable nullable context, or nullable warnings.",
+            mandatory = False,
+            default = "disable",
+            values = ["disable", "enable", "warnings", "annotations"],
+        ),
     },
 )
 

--- a/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
+++ b/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
@@ -78,7 +78,8 @@ def AssemblyAction(
         warnings_not_as_errors,
         warning_level,
         project_sdk,
-        allow_unsafe_blocks):
+        allow_unsafe_blocks,
+        nullable):
     """Creates an action that runs the CSharp compiler with the specified inputs.
 
     This macro aims to match the [C# compiler](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/listed-alphabetically), with the inputs mapping to compiler options.
@@ -112,6 +113,7 @@ def AssemblyAction(
         warning_level: The warning level to use.
         project_sdk: The project sdk being targeted
         allow_unsafe_blocks: Compiles the target with /unsafe
+        nullable: Enable nullable context, or nullable warnings.
     Returns:
         The compiled csharp artifacts.
     """
@@ -177,6 +179,7 @@ def AssemblyAction(
             warnings_not_as_errors,
             warning_level,
             allow_unsafe_blocks,
+            nullable,
             out_dll = out_dll,
             out_ref = out_ref,
             out_pdb = out_pdb,
@@ -220,6 +223,7 @@ def AssemblyAction(
             warnings_not_as_errors,
             warning_level,
             allow_unsafe_blocks,
+            nullable,
             out_ref = out_iref,
             out_dll = out_dll,
             out_pdb = out_pdb,
@@ -253,6 +257,7 @@ def AssemblyAction(
             warnings_not_as_errors,
             warning_level,
             allow_unsafe_blocks,
+            nullable,
             out_dll = None,
             out_ref = out_ref,
             out_pdb = None,
@@ -309,6 +314,7 @@ def _compile(
         warnings_not_as_errors,
         warning_level,
         allow_unsafe_blocks,
+        nullable,
         out_dll = None,
         out_ref = None,
         out_pdb = None):
@@ -332,6 +338,15 @@ def _compile(
         args.add("/highentropyva+")
     else:
         args.add("/highentropyva-")
+
+    if (nullable == "enable"):
+        args.add("/nullable:enable")
+    elif (nullable == "warnings"):
+        args.add("/nullable:warnings")
+    elif (nullable == "annotations"):
+        args.add("/nullable:annotations")
+    else:
+        args.add("/nullable:disable")
 
     if subsystem_version != None:
         args.add("/subsystemversion:" + subsystem_version)

--- a/dotnet/private/rules/csharp/binary.bzl
+++ b/dotnet/private/rules/csharp/binary.bzl
@@ -44,6 +44,7 @@ def _compile_action(ctx, tfm):
         warning_level = ctx.attr.warning_level if ctx.attr.override_warning_level else toolchain.dotnetinfo.csharp_warning_level[BuildSettingInfo].value,
         project_sdk = ctx.attr.project_sdk,
         allow_unsafe_blocks = ctx.attr.allow_unsafe_blocks,
+        nullable = ctx.attr.nullable,
     )
 
 def _binary_private_impl(ctx):

--- a/dotnet/private/rules/csharp/library.bzl
+++ b/dotnet/private/rules/csharp/library.bzl
@@ -43,6 +43,7 @@ def _compile_action(ctx, tfm):
         warning_level = ctx.attr.warning_level if ctx.attr.override_warning_level else toolchain.dotnetinfo.csharp_warning_level[BuildSettingInfo].value,
         project_sdk = ctx.attr.project_sdk,
         allow_unsafe_blocks = ctx.attr.allow_unsafe_blocks,
+        nullable = ctx.attr.nullable,
     )
 
 def _library_impl(ctx):

--- a/dotnet/private/rules/csharp/test.bzl
+++ b/dotnet/private/rules/csharp/test.bzl
@@ -46,6 +46,7 @@ def _compile_action(ctx, tfm):
         warning_level = ctx.attr.warning_level if ctx.attr.override_warning_level else toolchain.dotnetinfo.csharp_warning_level[BuildSettingInfo].value,
         project_sdk = ctx.attr.project_sdk,
         allow_unsafe_blocks = ctx.attr.allow_unsafe_blocks,
+        nullable = ctx.attr.nullable,
     )
 
 def _csharp_test_impl(ctx):

--- a/dotnet/private/tests/csharp_nullable/BUILD.bazel
+++ b/dotnet/private/tests/csharp_nullable/BUILD.bazel
@@ -1,0 +1,28 @@
+load(
+    "@rules_dotnet//dotnet:defs.bzl",
+    "csharp_library",
+    "csharp_nunit_test",
+)
+
+csharp_library(
+    name = "Nullable",
+    srcs = ["nullable.cs"],
+    nullable = "enable",
+    private_deps = [
+        "@rules_dotnet_dev_nuget_packages//microsoft.netcore.app.ref",
+    ],
+    target_frameworks = ["net6.0"],
+    treat_warnings_as_errors = True,
+)
+
+csharp_nunit_test(
+    name = "NullableTest",
+    srcs = ["nullabletest.cs"],
+    private_deps = [
+        "@rules_dotnet_dev_nuget_packages//microsoft.netcore.app.ref",
+    ],
+    target_frameworks = ["net6.0"],
+    deps = [
+        ":Nullable",
+    ],
+)

--- a/dotnet/private/tests/csharp_nullable/nullable.cs
+++ b/dotnet/private/tests/csharp_nullable/nullable.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Lib
+{
+    public static class NullableEntity
+    {
+        public static String? GetValue()
+        {
+            String? i = null;
+            return i;
+        }
+    }
+}

--- a/dotnet/private/tests/csharp_nullable/nullabletest.cs
+++ b/dotnet/private/tests/csharp_nullable/nullabletest.cs
@@ -1,0 +1,14 @@
+using Lib;
+using NUnit.Framework;
+using System.Linq;
+
+[TestFixture]
+public sealed class LibTests
+{
+    [Test]
+    public void LibCompilesAndValueIsNull()
+    {
+        Assert.AreEqual(NullableEntity.GetValue(), null);
+    }
+}
+


### PR DESCRIPTION
Adds the attribute `nullable` to csharp. It enables nullable context, or nullable warnings. The supported values are the same as description in the [C# Compiler options](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language#nullable), these being: `enable`, `disable`, `warnings`, or `annotations`.