### PR TITLE
Document invariant culture and RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,7 @@ test --test_output=errors
 
 # Remote config
 build:remote --remote_download_minimal
+build:remote --action_env=DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 
 # Profiling flags
 build --noslim_profile

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,3 +91,10 @@ and one of the reasons for Paket being a great fit with Bazel is that it support
 out of the box.
 
 See the [paket2bazel](tools/paket2bazel/) docs for instructions on how to set Paket up with Bazel.
+
+## Remote execution
+
+The rules support remote execution out of the box. The remote runners do need to have the required .Net
+system dependencies installed though. A common missing system dependency in existing RBE images is `libicu`.
+You can also work around the missing `libicu` by setting `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` using
+the `--action_env/--test_env/--host_action_env` Bazel flags.

--- a/dotnet/private/rules/common/binary.bzl
+++ b/dotnet/private/rules/common/binary.bzl
@@ -26,11 +26,6 @@ def _create_shim_exe(ctx, dll):
         inputs = depset([apphost, dll], transitive = [ctx.attr.apphost_shimmer.default_runfiles.files]),
         tools = [ctx.attr.apphost_shimmer.files, ctx.attr.apphost_shimmer.default_runfiles.files],
         outputs = [output],
-        env = {
-            # Set so that compilations work on remote execution workers that don't have ICU installed
-            # ICU should not be required during compliation but only at runtime
-            "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT": "1",
-        },
     )
 
     return output

--- a/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
+++ b/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
@@ -432,8 +432,5 @@ def _compile(
         ],
         env = {
             "DOTNET_CLI_HOME": toolchain.runtime.files_to_run.executable.dirname,
-            # Set so that compilations work on remote execution workers that don't have ICU installed
-            # ICU should not be required during compliation but only at runtime
-            "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT": "1",
         },
     )

--- a/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
+++ b/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
@@ -405,8 +405,5 @@ def _compile(
         ],
         env = {
             "DOTNET_CLI_HOME": toolchain.runtime.files_to_run.executable.dirname,
-            # Set so that compilations work on remote execution workers that don't have ICU installed
-            # ICU should not be required during compliation but only at runtime
-            "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT": "1",
         },
     )


### PR DESCRIPTION
## What?
Removes hardcoded DOTNET_SYSTEM_GLOBALIZATION_INVARIANT from the compilation actions
This waa orignally only intended as a fix for RBE where `libicu` is not installed. Instead of hardcoding
the env in the actions we just document this.
