### PR TITLE
Don't include SDK in runfiles for binaries

### DIFF
--- a/dotnet/repositories.bzl
+++ b/dotnet/repositories.bzl
@@ -84,7 +84,6 @@ filegroup(
     }}),
     data = glob([
         "host/**/*",
-        "sdk/**/*",
         "shared/Microsoft.NETCore.App/**/*",
     ]),
     visibility = ["//visibility:public"],

--- a/dotnet/repositories.bzl
+++ b/dotnet/repositories.bzl
@@ -84,6 +84,7 @@ filegroup(
     }}),
     data = glob([
         "host/**/*",
+        "sdk/{sdk_version}/Microsoft.NET.HostModel.dll",
         "shared/Microsoft.NETCore.App/**/*",
     ]),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
There are about 3700 files in the SDK, so this can take a while to run on slow file systems.

I measured the impact of this change on Windows by doing the following:

1. Editing `examples\basic_csharp\hello.cs`
2. Running `blaze build //basic_csharp:hello` from the examples directory.

Before this change the overall command reported taking about 10 seconds. Afterward it reported taking about 5 seconds.