### PR TITLE
Fix 'repo_mapping_manifest' property check for compatibility

### DIFF
--- a/dotnet/private/rules/publish_binary/publish_binary.bzl
+++ b/dotnet/private/rules/publish_binary/publish_binary.bzl
@@ -18,7 +18,10 @@ def _publish_binary_impl(ctx):
     elif len(ctx.attr.runtime_packs) > 0:
         fail("Can not do a framework dependent publish with a runtime pack")
 
-    repo_mapping_file = ctx.attr.binary[0][DefaultInfo].files_to_run.repo_mapping_manifest if ctx.attr.binary[0][DefaultInfo].files_to_run else None
+    # repo_mapping_manifest is only available in Bazel 7.0+
+    repo_mapping_file = None
+    if ctx.attr.binary[0][DefaultInfo].files_to_run and hasattr(ctx.attr.binary[0][DefaultInfo].files_to_run, "repo_mapping_manifest"):
+        repo_mapping_file = ctx.attr.binary[0][DefaultInfo].files_to_run.repo_mapping_manifest
 
     return [
         ctx.attr.binary[0][DotnetAssemblyCompileInfo],


### PR DESCRIPTION
Making it compatible with bazel6.

`repo_mapping_manifest` is added to `FilesToRunProvider` in bazel 7.0 via https://github.com/bazelbuild/bazel/pull/20022

Currently the code will access `repo_mapping_manifest` directly, which makes it only works for bazel >=7.0

This fix helps make the code compatible with bazel 6.0 by adding a attr check. When running on bazel 6.0：
- Before fix: `Error: 'FilesToRunProvider' value has no field or method 'repo_mapping_manifest'`
- After fix: (no error)