### PR TITLE
bugfix/issue-416-fsharp-debug-release-defines

### DIFF
--- a/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
+++ b/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
@@ -340,12 +340,14 @@ def _compile(
     if debug:
         args.add("--debug+")
         args.add("--optimize-")
-        args.add("--define:TRACE;DEBUG")
+        args.add("--define:TRACE")
+        args.add("--define:DEBUG")
         args.add("--tailcalls-")
     else:
         args.add("--debug-")
         args.add("--optimize+")
-        args.add("--define:TRACE;RELEASE")
+        args.add("--define:TRACE")
+        args.add("--define:RELEASE")
 
     args.add("--debug:portable")
 

--- a/examples/basic_fsharp/BUILD.bazel
+++ b/examples/basic_fsharp/BUILD.bazel
@@ -43,3 +43,15 @@ fsharp_library(
         "@paket.example_deps//fsharp.core",
     ],
 )
+
+fsharp_binary(
+    name = "release_mode",
+    srcs = ["release_mode.fs"],
+    target_frameworks = ["net6.0"],
+    targeting_packs = [
+        "@paket.example_deps//microsoft.netcore.app.ref",
+    ],
+    deps = [
+        "@paket.example_deps//fsharp.core",
+    ],
+)

--- a/examples/basic_fsharp/release_mode.fs
+++ b/examples/basic_fsharp/release_mode.fs
@@ -1,0 +1,20 @@
+open System
+
+#if DEBUG
+let debug = true
+#else
+let debug = false
+#endif
+
+#if RELEASE
+let release = true
+#else
+let release = false
+#endif
+
+[<EntryPoint>]
+let main args =
+    printfn $"DEBUG = %b{debug}"
+    printfn $"RELEASE = %b{release}"
+
+    0


### PR DESCRIPTION
Fix `DEBUG` and `RELEASE` defines in `fsharp_binary`. 

The issue is that `--define` can only set one symbol at a time. 

To see the fix working, run these in the `examples` workspace:

```bash
bazel run //basic_fsharp:release_mode
bazel run --compilation_mode=dbg //basic_fsharp:release_mode
```

Closes https://github.com/bazelbuild/rules_dotnet/issues/416