### PR TITLE
Remove unnecessary use of ctx.resolve_tools.

### DIFF
--- a/dotnet/private/tests/use_as_tool/run_rule/run_rule.bzl
+++ b/dotnet/private/tests/use_as_tool/run_rule/run_rule.bzl
@@ -2,13 +2,10 @@
 
 def _run_rule_impl(ctx):
     output = ctx.actions.declare_file("{}_out".format(ctx.label.name))
-    (inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr.tool])
 
     ctx.actions.run(
         outputs = [output],
         arguments = [output.path],
-        inputs = inputs,
-        input_manifests = input_manifests,
         executable = ctx.executable.tool,
     )
 

--- a/dotnet/private/tests/use_as_tool/run_shell_rule/run_shell_rule.bzl
+++ b/dotnet/private/tests/use_as_tool/run_shell_rule/run_shell_rule.bzl
@@ -2,13 +2,11 @@
 
 def _run_shell_rule_impl(ctx):
     output = ctx.actions.declare_file("{}_out".format(ctx.label.name))
-    (inputs, input_manifests) = ctx.resolve_tools(tools = [ctx.attr.tool])
 
     ctx.actions.run_shell(
         outputs = [output],
-        inputs = inputs,
-        input_manifests = input_manifests,
         command = "./{} {}".format(ctx.executable.tool.path, output.path),
+        tools = [ctx.executable.tool],
     )
 
     return [DefaultInfo(files = depset([output]))]


### PR DESCRIPTION
We'd like to retire this API, which is redundant with passing an `executable` or `tools` argument to `ctx.actions.run|run_shell`.