### PR TITLE
Use assembly name for DotnetAssembly{Compile,Runtime}Info

### DIFF
--- a/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
+++ b/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
@@ -275,7 +275,7 @@ def AssemblyAction(
         )
 
     return (DotnetAssemblyCompileInfo(
-        name = target_name,
+        name = assembly_name,
         version = "1.0.0",  #TODO: Maybe make this configurable?
         project_sdk = project_sdk,
         refs = [out_ref],
@@ -288,7 +288,7 @@ def AssemblyAction(
         transitive_analyzers = analyzers,
         transitive_compile_data = transitive_compile_data,
     ), DotnetAssemblyRuntimeInfo(
-        name = target_name,
+        name = assembly_name,
         version = "1.0.0",  #TODO: Maybe make this configurable?
         libs = [out_dll],
         pdbs = [out_pdb] if out_pdb else [],

--- a/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
+++ b/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
@@ -265,7 +265,7 @@ def AssemblyAction(
             )
 
     return (DotnetAssemblyCompileInfo(
-        name = target_name,
+        name = assembly_name,
         version = "1.0.0",  #TODO: Maybe make this configurable?
         project_sdk = project_sdk,
         refs = [out_dll],
@@ -278,7 +278,7 @@ def AssemblyAction(
         transitive_analyzers = analyzers,
         transitive_compile_data = transitive_compile_data,
     ), DotnetAssemblyRuntimeInfo(
-        name = target_name,
+        name = assembly_name,
         version = "1.0.0",  #TODO: Maybe make this configurable?
         libs = [out_dll],
         pdbs = [out_pdb] if out_pdb else [],


### PR DESCRIPTION
Previously, we used the name of the target directly, which caused problems in the following configuration:

```bazel
csharp_binary(
    name = "bar",
    out = "foo",
    // ...
)

publish_binary(
    name = "Bar",
    binary = ":bar",
)
```

`publish_binary` uses the name specified in `DotnetAssemblyRuntimeInfo` to generate the `{assembly}.deps.json` and `{assembly}.runtimeinfo.json` files, which are required for the .NET application to run. Since this was set to the target name, the generated filenames in the case above would be `bar.deps.json` and `bar.runtimeinfo.json`, causing the following error when trying to run the publish target:

    A fatal error was encountered. The library 'libhostpolicy.so' required to execute the application was not found in '/dotnet/sdk/path'.

The default case is unaffected, since `assembly_name` defaults to the `name` attribute if `out` is not given.