### PR TITLE
Update RBE runners to Ubuntu 20.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,7 +8,7 @@ matrix:
     [
       "windows",
       "ubuntu2004",
-      "rbe_ubuntu2004",
+      "rbe_ubuntu2204",
       "macos",
       "macos_arm64",
       "ubuntu2004_arm64",


### PR DESCRIPTION
## Why?
The 16.04 is both EOL and has a very old glibc