### PR TITLE
Use `exec` in Bash launcher template

### DIFF
--- a/dotnet/private/launcher.sh.tpl
+++ b/dotnet/private/launcher.sh.tpl
@@ -32,4 +32,4 @@ export DOTNET_NOLOGO="1"
 export DOTNET_CLI_TELEMETRY_OPTOUT="1"
 export DOTNET_ROOT="$(dirname $(rlocation TEMPLATED_dotnet))"
 
-$(rlocation TEMPLATED_dotnet) exec $(rlocation TEMPLATED_executable) "$@"
+exec $(rlocation TEMPLATED_dotnet) exec $(rlocation TEMPLATED_executable) "$@"


### PR DESCRIPTION
In `bazel test`, in macOS/Linux, all test rules are run under a script called `test-setup.sh`. This script does some extra work related to tests, and one of its tasks is cleaning up the remaining processes in the process group when the main test process exits.

When the user cancels a `bazel test` (or `build` for that matter) invocation using Ctrl+C, Bazel sends SIGTERM to all running processes. SIGTERM is then forwarded from `test-setup.sh` to all processes in the process group, and the script then waits for the test executable to exit. However, these two features interact badly when the test executable is Bash: the default behavior for SIGTERM in Bash is to exit immediately (for SIGINT and SIGQUIT Bash does something called "cooperative exit" where it waits for subprocesses to exit first before exiting itself). Because the Bash process is the test executable that is being waited on, this means `test-setup.sh` prematurely detects the entire test as having exited and cleans up by sending SIGKILL to the remaining processes in the process group, which means any cleanup actions by the C# process are preempted.

To ensure that `test-setup.sh` only performs cleanup when the test itself exits, we use `exec` so that the Bash process is replaced with `dotnet exec` which will only exit after the C# process itself handles the signal. This is fine since the `dotnet exec` command is the last command in the template.

I don't know how all of this behaves on Windows so I didn't touch the Windows template.