### PR TITLE
resolved_toolchain: Remove incompatible_use_toolchain_transition flag

### DIFF
--- a/dotnet/private/resolved_toolchain.bzl
+++ b/dotnet/private/resolved_toolchain.bzl
@@ -22,6 +22,5 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["//dotnet:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     doc = DOC,
 )


### PR DESCRIPTION
This flag has been obsolete since 2021 and was finally removed starting with Bazel 9. Removing this allows Bazel 9 to work with rules_dotnet.

Link: https://github.com/bazelbuild/bazel/issues/14127