### PR TITLE
Add env_inherit attribute for tests

### DIFF
--- a/dotnet/private/rules/common/attrs.bzl
+++ b/dotnet/private/rules/common/attrs.bzl
@@ -138,9 +138,9 @@ COMMON_ATTRS = {
 LIBRARY_COMMON_ATTRS = {
     "exports": attr.label_list(
         doc = """
-        List of targets to add to the dependencies of those that depend on this target. 
+        List of targets to add to the dependencies of those that depend on this target.
         Use this sparingly as it weakens the precision of the build graph.
-        
+
         This attribute does nothing if you don't have strict dependencies enabled.""",
         default = [],
         providers = [DotnetAssemblyCompileInfo, DotnetAssemblyRuntimeInfo],
@@ -171,6 +171,14 @@ BINARY_COMMON_ATTRS = {
     "envs": attr.string_dict(
         doc = "A dictionary of environment variables to set when the binary is run. Supports make variable expansion",
         default = {},
+    ),
+    "env_inherit": attr.string_list(
+        doc = "A list of environment variable names that are inherited from the external/client " +
+              "environment when the binary or test is run. Unlike `envs` " +
+              "(which sets static values), these forward the value present in the invoking " +
+              "environment at run/test time, so secrets and host-specific paths are not baked into " +
+              "the build graph.",
+        default = [],
     ),
     "_bash_runfiles": attr.label(
         default = "@rules_shell//shell/runfiles",

--- a/dotnet/private/rules/common/binary.bzl
+++ b/dotnet/private/rules/common/binary.bzl
@@ -183,4 +183,4 @@ def build_binary(ctx, compile_action):
         runtime_pack_info = ctx.attr._runtime_pack[0][DotnetRuntimePackInfo],
     )
 
-    return [default_info, dotnet_binary_info, compile_provider, runtime_provider, RunEnvironmentInfo(environment = {key: expand_variables(ctx, expand_locations(ctx, value, ctx.attr.data)) for key, value in ctx.attr.envs.items()})]
+    return [default_info, dotnet_binary_info, compile_provider, runtime_provider, RunEnvironmentInfo(environment = {key: expand_variables(ctx, expand_locations(ctx, value, ctx.attr.data)) for key, value in ctx.attr.envs.items()}, inherited_environment = ctx.attr.env_inherit)]

--- a/dotnet/private/tests/binary_envs/csharp/BUILD.bazel
+++ b/dotnet/private/tests/binary_envs/csharp/BUILD.bazel
@@ -3,7 +3,9 @@
 load(
     "//dotnet:defs.bzl",
     "csharp_nunit_test",
+    "csharp_test",
 )
+load("//dotnet/private/tests:utils.bzl", "run_environment_info_test")
 
 csharp_nunit_test(
     name = "test",
@@ -17,4 +19,17 @@ csharp_nunit_test(
         "TEMPLATED_VARIABLE": "$(DOTNET_SDK_VERSION)",
     },
     target_frameworks = ["net6.0"],
+)
+
+csharp_test(
+    name = "inherited_env_test_bin",
+    srcs = ["Inherit.cs"],
+    env_inherit = ["INHERITED_VAR"],
+    target_frameworks = ["net6.0"],
+)
+
+run_environment_info_test(
+    name = "env_inherit_test",
+    target_under_test = ":inherited_env_test_bin",
+    expected_inherited_environment = ["INHERITED_VAR"],
 )

--- a/dotnet/private/tests/binary_envs/csharp/BUILD.bazel
+++ b/dotnet/private/tests/binary_envs/csharp/BUILD.bazel
@@ -30,6 +30,6 @@ csharp_test(
 
 run_environment_info_test(
     name = "env_inherit_test",
-    target_under_test = ":inherited_env_test_bin",
     expected_inherited_environment = ["INHERITED_VAR"],
+    target_under_test = ":inherited_env_test_bin",
 )

--- a/dotnet/private/tests/binary_envs/csharp/Inherit.cs
+++ b/dotnet/private/tests/binary_envs/csharp/Inherit.cs
@@ -1,0 +1,3 @@
+class Inherit {
+    static void Main() {}
+}

--- a/dotnet/private/tests/utils.bzl
+++ b/dotnet/private/tests/utils.bzl
@@ -1,6 +1,6 @@
 "Test utilities"
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo")
 load("//dotnet/private:providers.bzl", "DotnetBinaryInfo")
@@ -80,3 +80,30 @@ def get_target_rid(target):
         return target[TestingAspectInfo].attrs.binary[0][DotnetBinaryInfo].runtime_pack_info.runtime_identifier
 
     fail("Could not determine target runtime identifier")
+
+RUN_ENVIRONMENT_INFO_TEST_ARGS = {
+    "expected_inherited_environment": attr.string_list(),
+}
+
+def _run_environment_info_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    if RunEnvironmentInfo not in target:
+        fail("Target does not return RunEnvironmentInfo provider")
+
+    run_env_info = target[RunEnvironmentInfo]
+
+    for expected in ctx.attr.expected_inherited_environment:
+        asserts.true(
+            env,
+            expected in run_env_info.inherited_environment,
+            "Expected inherited environment variable '{}' to be in '{}'".format(expected, run_env_info.inherited_environment),
+        )
+
+    return analysistest.end(env)
+
+run_environment_info_test = analysistest.make(
+    _run_environment_info_test_impl,
+    attrs = RUN_ENVIRONMENT_INFO_TEST_ARGS,
+)


### PR DESCRIPTION
This PR adds the [common test attribute](https://bazel.build/reference/be/common-definitions#common-attributes-tests) `env_inherit` that is found on other test libraries such as `cc_test`, `py_test`, and `sh_test`. 


This attribute allows for testing situations where the users local machine or CI needs to pass in credentials. For example if running tests using Testcontainers that has to pull down an image from a private registry, `env_inheirt` can be used to pass in the docker config location which will be based on their home directory `$HOME/.docker/config.json` and not rely on hard coding the path, which would be different for each user, if just the `env` attribute was used. We could also use `--test_env` to solve this but that would mean every test would get access to this variable where only ones that run a test container need it.