### PR TITLE
Include appsetting_files in runfiles

### DIFF
--- a/dotnet/private/rules/common/binary.bzl
+++ b/dotnet/private/rules/common/binary.bzl
@@ -96,7 +96,9 @@ def build_binary(ctx, compile_action):
     (compile_provider, runtime_provider) = compile_action(ctx, tfm)
     dll = runtime_provider.libs[0]
     default_info_files = [dll] + runtime_provider.xml_docs + runtime_provider.appsetting_files.to_list()
-    additional_runfiles = []
+
+    # appsetting_files must be in runfiles (not just DefaultInfo) so they're present when the target runs from an isolated runfiles tree (RBE/sandbox).
+    additional_runfiles = runtime_provider.appsetting_files.to_list()
 
     launcher = _create_launcher(ctx, additional_runfiles, dll)
 


### PR DESCRIPTION
appsetting_files end up in DefaultInfo.files but not in runfiles, so they're missing when a target runs from an isolated runfiles tree (remote execution / sandbox). Locally everything's next to the assembly so it works; on RBE the test fails with FileNotFound for filesettings.json.

One-line fix: seed additional_runfiles with appsetting_files.

Assuming this is just an oversight, but happy to close if appsetting files are intentionally kept out of runfiles.