### PR TITLE
Fix apphost shimmer toolchain selectin

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,16 +56,10 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependenc
 bazel_dep(name = "rules_cc", version = "0.2.19", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)
-bazel_dep(name = "llvm", version = "0.8.9", dev_dependency = True)
 bazel_dep(name = "dotnet_test_resources_other_repo", version = "", dev_dependency = True)
 local_path_override(
     module_name = "dotnet_test_resources_other_repo",
     path = "dotnet/private/tests/resources/other_repo",
-)
-
-register_toolchains(
-    "@llvm//toolchain:all",
-    dev_dependency = True,
 )
 
 rules_dotnet_dev_nuget_packages_extension = use_extension("@rules_dotnet//dotnet:paket.rules_dotnet_dev_nuget_packages_extension.bzl", "rules_dotnet_dev_nuget_packages_extension", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,10 @@ module(
 
 dotnet = use_extension("@rules_dotnet//dotnet:extensions.bzl", "dotnet")
 dotnet.toolchain(dotnet_version = "10.0.201")
+
+# This toolchain is used for building the apphost shimmer only. The apphost shimmer
+# can not be buit with the toolchain that the end-user picks because the apphost builder
+# always targets the latest SDK and the end-user can pick an older SDK that is incompatible with the apphost builder.
 dotnet.toolchain(
     name = "dotnet_apphost",
     dotnet_version = "10.0.201",
@@ -52,10 +56,16 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependenc
 bazel_dep(name = "rules_cc", version = "0.2.19", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)
+bazel_dep(name = "llvm", version = "0.8.9", dev_dependency = True)
 bazel_dep(name = "dotnet_test_resources_other_repo", version = "", dev_dependency = True)
 local_path_override(
     module_name = "dotnet_test_resources_other_repo",
     path = "dotnet/private/tests/resources/other_repo",
+)
+
+register_toolchains(
+    "@llvm//toolchain:all",
+    dev_dependency = True,
 )
 
 rules_dotnet_dev_nuget_packages_extension = use_extension("@rules_dotnet//dotnet:paket.rules_dotnet_dev_nuget_packages_extension.bzl", "rules_dotnet_dev_nuget_packages_extension", dev_dependency = True)

--- a/dotnet/private/rules/csharp/BUILD.bazel
+++ b/dotnet/private/rules/csharp/BUILD.bazel
@@ -11,6 +11,7 @@ bzl_library(
         "//dotnet/private/rules/common:attrs",
         "//dotnet/private/rules/common:binary",
         "//dotnet/private/rules/csharp/actions:csharp_assembly",
+        "//dotnet/private/transitions:default_transition",
         "//dotnet/private/transitions:tfm_transition",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//rules:common_settings",

--- a/dotnet/private/rules/csharp/BUILD.bazel
+++ b/dotnet/private/rules/csharp/BUILD.bazel
@@ -11,7 +11,7 @@ bzl_library(
         "//dotnet/private/rules/common:attrs",
         "//dotnet/private/rules/common:binary",
         "//dotnet/private/rules/csharp/actions:csharp_assembly",
-        "//dotnet/private/transitions:default_transition",
+        "//dotnet/private/transitions:apphost_shimmer_transition",
         "//dotnet/private/transitions:tfm_transition",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//rules:common_settings",

--- a/dotnet/private/rules/csharp/binary.bzl
+++ b/dotnet/private/rules/csharp/binary.bzl
@@ -12,6 +12,7 @@ load(
 load("//dotnet/private/rules/common:attrs.bzl", "CSHARP_BINARY_COMMON_ATTRS")
 load("//dotnet/private/rules/common:binary.bzl", "build_binary")
 load("//dotnet/private/rules/csharp/actions:csharp_assembly.bzl", "AssemblyAction")
+load("//dotnet/private/transitions:default_transition.bzl", "default_transition")
 load("//dotnet/private/transitions:tfm_transition.bzl", "tfm_transition")
 
 def _compile_action(ctx, tfm):
@@ -62,21 +63,41 @@ def _binary_private_impl(ctx):
     result = build_binary(ctx, _compile_action)
     return result
 
+_BINARY_ATTRS = dicts.add(
+    CSHARP_BINARY_COMMON_ATTRS,
+    {
+        "include_host_model_dll": attr.bool(
+            doc = "Whether to include Microsoft.NET.HostModel from the toolchain. This is only required to build tha apphost shimmer.",
+            default = False,
+        ),
+    },
+)
+
 csharp_binary = rule(
     _binary_private_impl,
     doc = """Compile a C# exe""",
-    attrs = dicts.add(
-        CSHARP_BINARY_COMMON_ATTRS,
-        {
-            "include_host_model_dll": attr.bool(
-                doc = "Whether to include Microsoft.NET.HostModel from the toolchain. This is only required to build tha apphost shimmer.",
-                default = False,
-            ),
-        },
-    ),
+    attrs = _BINARY_ATTRS,
     executable = True,
     toolchains = [
         "//dotnet:toolchain_type",
     ],
     cfg = tfm_transition,
+)
+
+# This rule is purely for building the apphost
+# shimmer. It is needed because the apphost shimmer
+# has to target the exec configuration but we can't
+# just set `cfg = "exec"` in publish_binary because
+# we also need to reset the TFM/RID graph back to the
+# defaults so that the publish_binary's target
+# framework does not infect the apphost shimmer build.
+apphost_shimmer_binary = rule(
+    _binary_private_impl,
+    doc = """Compile the apphost shimmer C# exe. See the comment in binary.bzl for why this is separate from `csharp_binary`.""",
+    attrs = _BINARY_ATTRS,
+    executable = True,
+    toolchains = [
+        "//dotnet:toolchain_type",
+    ],
+    cfg = default_transition,
 )

--- a/dotnet/private/rules/csharp/binary.bzl
+++ b/dotnet/private/rules/csharp/binary.bzl
@@ -12,7 +12,7 @@ load(
 load("//dotnet/private/rules/common:attrs.bzl", "CSHARP_BINARY_COMMON_ATTRS")
 load("//dotnet/private/rules/common:binary.bzl", "build_binary")
 load("//dotnet/private/rules/csharp/actions:csharp_assembly.bzl", "AssemblyAction")
-load("//dotnet/private/transitions:default_transition.bzl", "default_transition")
+load("//dotnet/private/transitions:apphost_shimmer_transition.bzl", "apphost_shimmer_transition")
 load("//dotnet/private/transitions:tfm_transition.bzl", "tfm_transition")
 
 def _compile_action(ctx, tfm):
@@ -93,11 +93,11 @@ csharp_binary = rule(
 # framework does not infect the apphost shimmer build.
 apphost_shimmer_binary = rule(
     _binary_private_impl,
-    doc = """Compile the apphost shimmer C# exe. See the comment in binary.bzl for why this is separate from `csharp_binary`.""",
+    doc = """Compile the apphost shimmer C# exe.""",
     attrs = _BINARY_ATTRS,
     executable = True,
     toolchains = [
         "//dotnet:toolchain_type",
     ],
-    cfg = default_transition,
+    cfg = apphost_shimmer_transition,
 )

--- a/dotnet/private/rules/publish_binary/publish_binary.bzl
+++ b/dotnet/private/rules/publish_binary/publish_binary.bzl
@@ -6,7 +6,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//dotnet/private:common.bzl", "generate_depsjson", "generate_runtimeconfig")
 load("//dotnet/private:providers.bzl", "DotnetAssemblyCompileInfo", "DotnetAssemblyRuntimeInfo", "DotnetBinaryInfo")
-load("//dotnet/private/transitions:default_transition.bzl", "default_transition")
 load("//dotnet/private/transitions:tfm_transition.bzl", "tfm_transition")
 
 def _copy_file(script_body, src, dst, is_windows):
@@ -193,10 +192,10 @@ def _create_shim_exe(ctx, apphost_pack_info, dll, runtime_identifier):
     output = ctx.actions.declare_file(paths.replace_extension(dll.basename, ".exe" if ctx.target_platform_has_constraint(windows_constraint) else ""), sibling = dll)
 
     ctx.actions.run(
-        executable = ctx.attr._apphost_shimmer[0].files_to_run,
+        executable = ctx.attr._apphost_shimmer.files_to_run,
         arguments = [apphost.path, dll.path, output.path, runtime_identifier],
-        inputs = depset([apphost, dll], transitive = [ctx.attr._apphost_shimmer[0].default_runfiles.files]),
-        tools = [ctx.attr._apphost_shimmer[0].files, ctx.attr._apphost_shimmer[0].default_runfiles.files],
+        inputs = depset([apphost, dll], transitive = [ctx.attr._apphost_shimmer.default_runfiles.files]),
+        tools = [ctx.attr._apphost_shimmer.files, ctx.attr._apphost_shimmer.default_runfiles.files],
         outputs = [output],
     )
 
@@ -332,7 +331,7 @@ publish_binary = rule(
             providers = [DotnetAssemblyCompileInfo, DotnetAssemblyRuntimeInfo],
             executable = True,
             default = "//dotnet/private/tools/apphost_shimmer:apphost_shimmer",
-            cfg = default_transition,
+            cfg = "exec",
         ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",

--- a/dotnet/private/tools/apphost_shimmer/BUILD.bazel
+++ b/dotnet/private/tools/apphost_shimmer/BUILD.bazel
@@ -1,9 +1,9 @@
 load(
-    "//dotnet:defs.bzl",
-    "csharp_binary",
+    "//dotnet/private/rules/csharp:binary.bzl",
+    "apphost_shimmer_binary",
 )
 
-csharp_binary(
+apphost_shimmer_binary(
     name = "apphost_shimmer",
     srcs = [
         "AppHostShellShimMaker.cs",

--- a/dotnet/private/transitions/BUILD.bazel
+++ b/dotnet/private/transitions/BUILD.bazel
@@ -7,6 +7,7 @@ bzl_library(
     deps = [
         "//dotnet/private:common",
         "@bazel_skylib//lib:sets",
+        "@platforms//host:constraints_lib",
     ],
 )
 
@@ -18,7 +19,6 @@ bzl_library(
         ":common",
         "//dotnet/private:common",
         "@bazel_skylib//lib:dicts",
-        "@platforms//host:constraints_lib",
     ],
 )
 
@@ -29,6 +29,18 @@ bzl_library(
     deps = [
         ":common",
         "//dotnet/private:common",
+        "@bazel_skylib//lib:dicts",
+    ],
+)
+
+bzl_library(
+    name = "apphost_shimmer_transition",
+    srcs = ["apphost_shimmer_transition.bzl"],
+    visibility = ["//dotnet:__subpackages__"],
+    deps = [
+        ":common",
+        "//dotnet/private:common",
+        "//dotnet/private/sdk:rids",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/dotnet/private/transitions/apphost_shimmer_transition.bzl
+++ b/dotnet/private/transitions/apphost_shimmer_transition.bzl
@@ -1,0 +1,37 @@
+"""Incoming transition for the `apphost_shimmer_binary` rule.
+
+This transition makes sure that the apphost shimmer is always transitioned to
+the default TFM and the RID of the host platform. This is needed because
+# the apphost shimmer is always built for the exec platform.
+"""
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load(
+    "//dotnet/private:common.bzl",
+    "DEFAULT_TFM",
+    "FRAMEWORK_COMPATIBILITY",
+)
+load("//dotnet/private/sdk:rids.bzl", "RUNTIME_GRAPH")
+load(
+    "//dotnet/private/transitions:common.bzl",
+    "FRAMEWORK_COMPATABILITY_TRANSITION_OUTPUTS",
+    "RID_COMPATABILITY_TRANSITION_OUTPUTS",
+    "platform_to_rid",
+)
+
+def _impl(_settings, _attr):
+    tfm = DEFAULT_TFM
+    rid = platform_to_rid()
+    return dicts.add(
+        {"//dotnet:target_framework": tfm, "//dotnet:rid": rid},
+        FRAMEWORK_COMPATABILITY_TRANSITION_OUTPUTS[tfm],
+        RID_COMPATABILITY_TRANSITION_OUTPUTS[rid],
+    )
+
+apphost_shimmer_transition = transition(
+    implementation = _impl,
+    inputs = [],
+    outputs = ["//dotnet:target_framework", "//dotnet:rid"] +
+              ["//dotnet:framework_compatible_%s" % framework for framework in FRAMEWORK_COMPATIBILITY.keys()] +
+              ["//dotnet:rid_compatible_%s" % rid for rid in RUNTIME_GRAPH.keys()],
+)

--- a/dotnet/private/transitions/common.bzl
+++ b/dotnet/private/transitions/common.bzl
@@ -1,12 +1,49 @@
 "Common functinality for transitions"
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load(
     "//dotnet/private:common.bzl",
     "FRAMEWORK_COMPATIBILITY",
     "TRANSITIVE_FRAMEWORK_COMPATIBILITY",
 )
 load("//dotnet/private/sdk:rids.bzl", "RUNTIME_GRAPH")
+
+def platform_to_rid():
+    """Determines the .Net runtime identifier (RID) of the host that Bazel is running on.
+
+    Returns:
+        The .Net RID of the host platform, e.g. "osx-arm64", "linux-x64" or "win-x64".
+    """
+    cpu_constraint = None
+    os_constraint = None
+    for platform in HOST_CONSTRAINTS:
+        if platform.startswith("@platforms//cpu"):
+            cpu_constraint = platform.split(":")[1]
+        if platform.startswith("@platforms//os"):
+            os_constraint = platform.split(":")[1]
+
+    if cpu_constraint == None or os_constraint == None:
+        fail("Could not determine the cpu or os constraint: {}/{}".format(cpu_constraint, os_constraint))
+
+    rid_cpu = None
+    rid_os = None
+    if os_constraint == "windows":
+        rid_os = "win"
+    elif os_constraint == "linux":
+        rid_os = "linux"
+    elif os_constraint == "macos" or os_constraint == "osx":
+        rid_os = "osx"
+
+    if cpu_constraint == "x86_64":
+        rid_cpu = "x64"
+    elif cpu_constraint == "aarch64" or cpu_constraint == "arm64":
+        rid_cpu = "arm64"
+
+    if rid_cpu == None or rid_os == None:
+        fail("Could not determine the rid from the cpu/os constraint: {}/{}".format(cpu_constraint, os_constraint))
+
+    return "{}-{}".format(rid_os, rid_cpu)
 
 FRAMEWORK_COMPATABILITY_TRANSITION_OUTPUTS = {
     tfm: {

--- a/dotnet/private/transitions/tfm_transition.bzl
+++ b/dotnet/private/transitions/tfm_transition.bzl
@@ -1,45 +1,13 @@
 "A transition that transitions between compatible target frameworks"
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load(
     "//dotnet/private:common.bzl",
     "FRAMEWORK_COMPATIBILITY",
     "get_highest_compatible_target_framework",
 )
 load("//dotnet/private/sdk:rids.bzl", "RUNTIME_GRAPH")
-load("//dotnet/private/transitions:common.bzl", "FRAMEWORK_COMPATABILITY_TRANSITION_OUTPUTS", "RID_COMPATABILITY_TRANSITION_OUTPUTS")
-
-def _platform_to_rid():
-    cpu_constraint = None
-    os_constraint = None
-    for platform in HOST_CONSTRAINTS:
-        if platform.startswith("@platforms//cpu"):
-            cpu_constraint = platform.split(":")[1]
-        if platform.startswith("@platforms//os"):
-            os_constraint = platform.split(":")[1]
-
-    if cpu_constraint == None or os_constraint == None:
-        fail("Could not determine the cpu or os constraint: {}/{}".format(cpu_constraint, os_constraint))
-
-    rid_cpu = None
-    rid_os = None
-    if os_constraint == "windows":
-        rid_os = "win"
-    elif os_constraint == "linux":
-        rid_os = "linux"
-    elif os_constraint == "macos" or os_constraint == "osx":
-        rid_os = "osx"
-
-    if cpu_constraint == "x86_64":
-        rid_cpu = "x64"
-    elif cpu_constraint == "aarch64" or cpu_constraint == "arm64":
-        rid_cpu = "arm64"
-
-    if rid_cpu == None or rid_os == None:
-        fail("Could not determine the rid from the cpu/os constraint: {}/{}".format(cpu_constraint, os_constraint))
-
-    return "{}-{}".format(rid_os, rid_cpu)
+load("//dotnet/private/transitions:common.bzl", "FRAMEWORK_COMPATABILITY_TRANSITION_OUTPUTS", "RID_COMPATABILITY_TRANSITION_OUTPUTS", "platform_to_rid")
 
 def _impl(settings, attr):
     incoming_tfm = settings["//dotnet:target_framework"]
@@ -63,7 +31,7 @@ def _impl(settings, attr):
         runtime_identifier = attr.runtime_identifier
     elif runtime_identifier == "base":
         # If the runtime_identifier attribute is not set and the incoming value is "base", we will use the platform to determine the rid since no upstream target has set the runtime identifier
-        runtime_identifier = _platform_to_rid()
+        runtime_identifier = platform_to_rid()
 
     return dicts.add({"//dotnet:target_framework": transitioned_tfm}, {"//dotnet:rid": runtime_identifier}, FRAMEWORK_COMPATABILITY_TRANSITION_OUTPUTS[transitioned_tfm], RID_COMPATABILITY_TRANSITION_OUTPUTS[runtime_identifier])
 


### PR DESCRIPTION
## What?
Fixes the toolchain selection for the build of apphost shimmer. It was being built in the `target` configuration but should have been built in `exec`