### PR TITLE
feat(nuget): support local package artifacts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,6 +65,12 @@ local_path_override(
 rules_dotnet_dev_nuget_packages_extension = use_extension("@rules_dotnet//dotnet:paket.rules_dotnet_dev_nuget_packages_extension.bzl", "rules_dotnet_dev_nuget_packages_extension", dev_dependency = True)
 use_repo(rules_dotnet_dev_nuget_packages_extension, "paket.rules_dotnet_dev_nuget_packages")
 
+local_package_artifact = use_extension("@rules_dotnet//dotnet/private/tests/nuget_structure:local_package.bzl", "local_package_artifact", dev_dependency = True)
+use_repo(local_package_artifact, "local_nuget_package_artifact")
+
+local_package_test = use_extension("@rules_dotnet//dotnet/private/tests/nuget_structure:local_package.bzl", "local_package_test", dev_dependency = True)
+use_repo(local_package_test, "local_nuget_package_test")
+
 rules_dotnet_nuget_resource_assemblies_tests_extension = use_extension("@rules_dotnet//dotnet:paket.rules_dotnet_nuget_resource_assemblies_tests_extension.bzl", "rules_dotnet_nuget_resource_assemblies_tests_extension", dev_dependency = True)
 use_repo(rules_dotnet_nuget_resource_assemblies_tests_extension, "paket.rules_dotnet_nuget_resource_assemblies_tests")
 

--- a/dotnet/private/rules/nuget/nuget_archive.bzl
+++ b/dotnet/private/rules/nuget/nuget_archive.bzl
@@ -401,20 +401,24 @@ def _get_auth_dict(ctx, netrc, urls):
     return cred_dict
 
 def _nuget_archive_impl(ctx):
-    # First get the auth dict for the package sources since the sources can be different than the
-    # package base url when using NuGet V3 feeds.
-    auth = _get_auth_dict(ctx, ctx.attr.netrc, ctx.attr.sources)
-    urls = _get_package_urls(ctx, ctx.attr.sources, auth, ctx.attr.id, ctx.attr.version)
-
-    # Then get the auth dict for the package base urls
-    auth = _get_auth_dict(ctx, ctx.attr.netrc, urls)
-
     # We download it as .zip because ctx.exract reads the file extension to determine the archive type
     file_name = "%s.zip" % ctx.name
     nupkg_name = "%s.%s.nupkg" % (ctx.attr.id, ctx.attr.version)
     names = [nupkg_name]
 
-    ctx.download(urls, output = file_name, integrity = ctx.attr.sha512, auth = auth)
+    if ctx.attr.local_package:
+        local_path = str(ctx.path(ctx.attr.local_package)).replace("\\\\", "/")
+        local_url = "file://" + (local_path if local_path.startswith("/") else "/" + local_path)
+        ctx.download(local_url, output = file_name, integrity = ctx.attr.sha512)
+    else:
+        # First get the auth dict for the package sources since the sources can be different than the
+        # package base url when using NuGet V3 feeds.
+        auth = _get_auth_dict(ctx, ctx.attr.netrc, ctx.attr.sources)
+        urls = _get_package_urls(ctx, ctx.attr.sources, auth, ctx.attr.id, ctx.attr.version)
+
+        # Then get the auth dict for the package base urls.
+        auth = _get_auth_dict(ctx, ctx.attr.netrc, urls)
+        ctx.download(urls, output = file_name, integrity = ctx.attr.sha512, auth = auth)
     ctx.extract(archive = file_name)
     for name in names:
         ctx.symlink(file_name, name)
@@ -574,6 +578,7 @@ nuget_archive = repository_rule(
         "id": attr.string(),
         "version": attr.string(),
         "sha512": attr.string(),
+        "local_package": attr.label(allow_single_file = True),
     },
 )
 

--- a/dotnet/private/rules/nuget/nuget_repo.bzl
+++ b/dotnet/private/rules/nuget/nuget_repo.bzl
@@ -125,12 +125,14 @@ def nuget_repo(name, packages):
     for package in packages:
         id = package["id"].lower()
         version = package["version"].lower()
+        local_package = package.pop("local_package", None)
 
         # maybe another nuget_repo has the same nuget package dependency
         maybe(
             nuget_archive,
             name = "{}.{}.v{}".format(_GLOBAL_NUGET_PREFIX, id, version),
-            sources = package["sources"],
+            sources = package.get("sources", []),
+            local_package = local_package,
             netrc = package.get("netrc", None),
             id = id,
             version = version,

--- a/dotnet/private/tests/nuget_structure/BUILD.bazel
+++ b/dotnet/private/tests/nuget_structure/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load(":analyzers.bzl", "analyzers_structure")
+load(":local_package.bzl", "local_package_structure")
 load(":resolution.bzl", "resolution_structure")
 load(":resource_assemblies.bzl", "resource_assemblies")
 load(":runtimes.bzl", "runtimes_structure")
@@ -16,6 +17,8 @@ resolution_structure()
 resource_assemblies()
 
 analyzers_structure()
+
+local_package_structure()
 
 targetingpacks_structure()
 
@@ -64,6 +67,17 @@ bzl_library(
     srcs = ["analyzers.bzl"],
     visibility = ["//dotnet:__subpackages__"],
     deps = [":common"],
+)
+
+bzl_library(
+    name = "local_package_bzl",
+    srcs = ["local_package.bzl"],
+    visibility = ["//dotnet:__subpackages__"],
+    deps = [
+        ":common",
+        "//dotnet:defs",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+    ],
 )
 
 select_file(

--- a/dotnet/private/tests/nuget_structure/local_package.bzl
+++ b/dotnet/private/tests/nuget_structure/local_package.bzl
@@ -1,0 +1,73 @@
+"NuGet package structure tests using a local package artifact."
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@rules_dotnet//dotnet:defs.bzl", "nuget_repo")
+load(":common.bzl", "nuget_structure_test", "nuget_test_wrapper")
+
+def _local_package_artifact_impl(module_ctx):
+    _ = module_ctx  # @unused
+    http_file(
+        name = "local_nuget_package_artifact",
+        urls = ["https://www.nuget.org/api/v2/package/FSharp.Core/9.0.300"],
+        integrity = "sha512-VmGyQ5hzaEvOHR2NnSlGHeGJzDH8j/GAil0pVAVxFv1YhQO6/OSLab7MWN5adsB7GYWsDVhU4YiSMDy+rA/2EQ==",
+    )
+    return module_ctx.extension_metadata(reproducible = True)
+
+local_package_artifact = module_extension(
+    implementation = _local_package_artifact_impl,
+)
+
+def _local_package_test_impl(module_ctx):
+    _ = module_ctx  # @unused
+    nuget_repo(
+        name = "local_nuget_package_test",
+        packages = [
+            {
+                "name": "LocalNuGetPackage",
+                "id": "LocalNuGetPackage",
+                "version": "1.0.0",
+                "sha512": "sha512-VmGyQ5hzaEvOHR2NnSlGHeGJzDH8j/GAil0pVAVxFv1YhQO6/OSLab7MWN5adsB7GYWsDVhU4YiSMDy+rA/2EQ==",
+                "local_package": Label("@local_nuget_package_artifact//file"),
+                "dependencies": {},
+                "targeting_pack_overrides": [],
+                "framework_list": [],
+                "tools": {},
+            },
+        ],
+    )
+    return module_ctx.extension_metadata(reproducible = True)
+
+local_package_test = module_extension(
+    implementation = _local_package_test_impl,
+)
+
+# buildifier: disable=function-docstring
+def local_package_structure():
+    nuget_test_wrapper(
+        name = "local_package",
+        target_framework = "netstandard2.1",
+        runtime_identifier = "linux-x64",
+        package = "@local_nuget_package_test//localnugetpackage",
+    )
+
+    nuget_structure_test(
+        name = "should_parse_local_package",
+        target_under_test = ":local_package",
+        expected_libs = ["lib/netstandard2.1/FSharp.Core.dll"],
+        expected_refs = ["lib/netstandard2.1/FSharp.Core.dll"],
+        expected_resource_assemblies = [
+            "lib/netstandard2.1/cs/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/de/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/es/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/fr/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/it/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/ja/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/ko/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/pl/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/pt-BR/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/ru/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/tr/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/zh-Hans/FSharp.Core.resources.dll",
+            "lib/netstandard2.1/zh-Hant/FSharp.Core.resources.dll",
+        ],
+    )


### PR DESCRIPTION
## Summary
- add an optional local_package label to 
uget_repo package entries
- retrieve local .nupkg files through the same SHA-512-verified archive path
- add a Bzlmod regression test that feeds a downloaded package artifact into 
uget_repo as a local label

## Testing
- azelisk build //dotnet/private/tests/nuget_structure:local_package_bzl`n- azelisk test //dotnet/private/tests/nuget_structure:should_parse_local_package --test_output=errors`n- azelisk test //dotnet/private/tests/nuget_structure:all --test_output=errors (35/36 pass; one existing Windows runfiles path-length failure could not chdir)